### PR TITLE
convert-aws-account-to-string

### DIFF
--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -37,4 +37,4 @@ machinePools:
   - label=default
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-flatcarAWSAccount: 075585003325
+flatcarAWSAccount: "075585003325"


### PR DESCRIPTION
```
    reason: 'Upgrade "vacl7" failed: failed to create resource: AWSMachineTemplate.infrastructure.cluster.x-k8s.io
      "vacl7-bastion" is invalid: spec.template.spec.imageLookupOrg: Invalid value:
      "integer": spec.template.spec.imageLookupOrg in body must be of type string:
      "integer"'
```