### PR TITLE
rename networkSpec to network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Rename `networkSpec` to `network` in AWSCluster CR due renaming in `v1beta1`.
+
 ## [0.1.12] - 2022-03-18
 
 - Prefix machine pool with cluster id.

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -15,6 +15,14 @@ spec:
   networkSpec:
     cni:
       cniIngressRules:
+      - description: bgp (calico)
+        fromPort: 179
+        protocol: tcp
+        toPort: 179
+      - description: IP-in-IP (calico)
+        fromPort: -1
+        protocol: "4"
+        toPort: 65535
       - description: allow cni traffic across nodes and control plane
         fromPort: -1
         protocol: "-1"

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -12,17 +12,9 @@ spec:
   identityRef:
     kind: AWSClusterRoleIdentity
     name: {{ .Values.aws.awsClusterRole }}
-  networkSpec:
+  network:
     cni:
       cniIngressRules:
-      - description: bgp (calico)
-        fromPort: 179
-        protocol: tcp
-        toPort: 179
-      - description: IP-in-IP (calico)
-        fromPort: -1
-        protocol: "4"
-        toPort: 65535
       - description: allow cni traffic across nodes and control plane
         fromPort: -1
         protocol: "-1"

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -15,7 +15,7 @@ spec:
   network:
     cni:
       cniIngressRules:
-      - description: allow cni traffic across nodes and control plane
+      - description: allow AWS CNI traffic across nodes and control plane
         fromPort: -1
         protocol: "-1"
         toPort: -1


### PR DESCRIPTION
when those rules is missing in the CRS, capa will empty the rules and add them,  causing removal of the rules we set for was cni