### PR TITLE
Lookup region and AZs from management cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Lookup AWS region if not set in values
+- Lookup AWS Availability Zones if not set in values
 
 ## [0.2.0] - 2022-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lookup AWS region if not set in values
+
+## [0.2.0] - 2022-03-29
+
 - Allow app platform to take over managing coredns
 
 ## [0.1.14] - 2022-03-22
@@ -74,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-02-25
 
-[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v0.1.14...HEAD
+[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/giantswarm/cluster-aws/compare/v0.1.14...v0.2.0
 [0.1.14]: https://github.com/giantswarm/cluster-aws/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/giantswarm/cluster-aws/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/giantswarm/cluster-aws/compare/v0.1.11...v0.1.12

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -23,5 +23,5 @@ spec:
         availabilityZoneUsageLimit: {{ .Values.network.availabilityZoneUsageLimit }}
         cidrBlock: {{ .Values.network.vpcCIDR }}
   sshKeyName: ssh-key
-  region: {{ .Values.aws.region }}
+  region: {{ include "aws-region" . }}
 {{ end }}

--- a/helm/cluster-aws/templates/_awsazs.tpl
+++ b/helm/cluster-aws/templates/_awsazs.tpl
@@ -1,0 +1,11 @@
+{{- /*
+If no availability zones are provided in the values we'll attempt to look it up based on the AZs used by the management cluster
+*/}}
+{{- define "aws-availability-zones" }}
+{{- $azs := [] }}
+{{- range $nodes }}
+{{- $az = (get .metadata.labels "topology.kubernetes.io/zone") }}
+{{- $azs = append $azs $az}}
+{{- end }}
+{{- $azs | unique }}
+{{- end }}

--- a/helm/cluster-aws/templates/_awsregion.tpl
+++ b/helm/cluster-aws/templates/_awsregion.tpl
@@ -1,0 +1,16 @@
+{{- /*
+If no region is provided in the values we'll attempt to look it up based on the region used by the management cluster
+*/}}
+{{- define "aws-region" }}
+{{- $region := .Values.aws.region }}
+{{- if not $region }}
+{{- $nodes :=  (lookup "v1" "Node" "" "" ).items }}
+{{- if $nodes }}
+{{- if (gt (len $nodes) 0) }}
+{{- $node := (first $nodes) }}
+{{- $region = (get $node.metadata.labels "topology.kubernetes.io/region") }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $region }}
+{{- end }}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -36,7 +36,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ .name }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  availabilityZones: {{ .availabilityZones }}
+  availabilityZones: {{ .availabilityZones | default (include "aws-availability-zones" .) }}
   awsLaunchTemplate:
     ami: {}
     iamInstanceProfile: nodes-{{ .name }}-{{ include "resource.default.name" $ }}

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -23,7 +23,6 @@ controlPlane:
   etcdVolumeSizeGB: 100
   containerdVolumeSizeGB: 100
   kubeletVolumeSizeGB: 100
-  availabilityZones:
 
 machinePools:
 - name: def00  # Name of node pool.

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -4,7 +4,7 @@ kubernetesVersion: 1.22.7
 releaseVersion: 20.0.0-alpha1
 
 aws:
-  region: eu-west-1
+  region: ""
   awsClusterRole: "default"
 
 network:


### PR DESCRIPTION
* If the AWS region isn't set in the variables we'll attempt to pull it from the management cluster
* If the availability zones on a node pool aren't set we'll pull them from the management cluster

Towards: https://github.com/giantswarm/giantswarm/issues/21298