### PR TITLE
Updated to use latest cluster-shared library chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Changed
+
+- Updated to latest `cluster-shared` library chart
+
+### Added
+
+- Support for specifying the `clusterName` (defaults to chart release name)
 
 ## [0.3.0] - 2022-04-12
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.1.1
-digest: sha256:ad005ba020a66f613d8c091bae6c95440248fc6ef40b81c2a75282e5fb6b762a
-generated: "2022-04-12T10:07:13.003183+01:00"
+  version: 0.3.0
+digest: sha256:4fe093f2b380650db63dc087435314bfdc33f9f4c6c3e96e4c40c3be377942f2
+generated: "2022-04-13T15:14:48.548668+01:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -10,5 +10,5 @@ restrictions:
     - aws
 dependencies:
 - name: cluster-shared
-  version: "0.1.1"
+  version: "0.3.0"
   repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -21,12 +21,12 @@ Common labels
 app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . }}
+cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 cluster.x-k8s.io/watch-filter: capi
-giantswarm.io/cluster: {{ include "resource.default.name" . }}
-giantswarm.io/organization: {{ .Values.organization }}
+giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
+giantswarm.io/organization: {{ .Values.organization | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
-release.giantswarm.io/version: {{ .Values.releaseVersion }}
+release.giantswarm.io/version: {{ .Values.releaseVersion | quote }}
 {{- end -}}
 
 {{/*
@@ -36,7 +36,7 @@ Given that Kubernetes allows 63 characters for resource names, the stem is trunc
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- .Values.clusterName | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
 
@@ -67,7 +67,7 @@ room for such suffix.
   permissions: "0600"
   contentFrom:
     secret:
-      name: {{ include "resource.default.name" $ }}-encryption-provider-config 
+      name: {{ include "resource.default.name" $ }}-encryption-provider-config
       key: encryption
 {{- end -}}
 

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -1,6 +1,7 @@
-{{- include "shared.default-psps" . }}
 ---
-{{- include "shared.coredns-adopter" . }}
+{{- include "coredns" . }}
+---
+{{- include "psps" . }}
 ---
 {{- include "cluster" . }}
 ---

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,5 +1,6 @@
+clusterName: ""  # Cluster name. Defaults to chart release name
 clusterDescription: "test"  # Cluster description used in metadata.
-organization: "test"  # Organization in which to create the cluster.
+organization: ""  # Organization in which to create the cluster.
 kubernetesVersion: 1.22.7
 releaseVersion: 20.0.0-alpha1
 
@@ -37,6 +38,8 @@ machinePools:
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 flatcarAWSAccount: "075585003325"
 
+# Used by `cluster-shared` library chart
+includeClusterResourceSet: true
 kubectlImage:
   registry: quay.io
   name: giantswarm/kubectl


### PR DESCRIPTION
Updated to use the latest https://github.com/giantswarm/cluster-shared as a library chart.

We are also explicitly setting the values the library will use (even though they are same as the defaults) to make it clear what values are used.

Added support for providing a custom `clusterName` value which defaults to the release name if not provided (as with the pre-existing behaviour)