### PR TITLE
Set pod CIDR range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set pod CIDR to 100.64.0.0/12 to match what we set in Cilium (and to not clash with AWS CIDR)
+
 ## [0.4.2] - 2022-07-25
 
 ### Changed

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -10,6 +10,9 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
 spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: {{ .Values.network.podCIDR }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -54,6 +54,8 @@ spec:
         extraArgs:
           bind-address: 0.0.0.0
           cloud-provider: aws
+          allocate-node-cidrs: true
+          cluster-cidr: {{ .Values.network.podCIDR }}
       scheduler:
         extraArgs:
           bind-address: 0.0.0.0

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -117,6 +117,9 @@
                 "availabilityZoneUsageLimit": {
                     "type": "integer"
                 },
+                "podCIDR": {
+                    "type": "string"
+                },
                 "serviceCIDR": {
                     "type": "string"
                 },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -12,6 +12,7 @@ network:
   availabilityZoneUsageLimit: 3  # amount of AZ that should be used for the machines
   vpcCIDR: 10.0.0.0/16  # cidr range for the VPC
   serviceCIDR: 172.31.0.0/16
+  podCIDR: 100.64.0.0/12
 
 bastion:
   enabled: true


### PR DESCRIPTION
Set pod CIDR to 100.64.0.0/12 to match what we set in Cilium (and to not clash with AWS CIDR) and add needed flags to controller-manager 