### PR TITLE
Switch to using GS-built AMIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+helm/cluster-aws/charts
+helm/rendered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use our Giant Swarm built AMIs
+
 ## [0.6.2] - 2022-08-06
 
 ### Fixed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,3 +1,9 @@
+.PHONY: template
+template:
+	@cd helm/cluster-aws && \
+		sed -i '' 's/version: \[/version: 1 #\[/' Chart.yaml && \
+		helm template . && \
+		sed -i '' 's/version: 1 #\[/version: \[/' Chart.yaml
 
 ensure-schema-gen:
 	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -73,7 +73,8 @@ spec:
           - owned
       cloudInit:
         insecureSkipSecretsManager: true
-      {{- include "ami" $ | nindent 6 }}
+      imageLookupFormat: Flatcar-stable-*
+      imageLookupOrg: "{{ .Values.flatcarAWSAccount }}"
       publicIP: true
       sshKeyName: ""
       subnet:

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -73,8 +73,7 @@ spec:
           - owned
       cloudInit:
         insecureSkipSecretsManager: true
-      imageLookupFormat: Flatcar-stable-*
-      imageLookupOrg: "{{ .Values.flatcarAWSAccount }}"
+      {{- include "ami" $ | nindent 6 }}
       publicIP: true
       sshKeyName: ""
       subnet:

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -115,7 +115,7 @@ spec:
         cluster.x-k8s.io/role: control-plane
         {{- include "labels.common" $ | nindent 8 }}
     spec:
-      ami: {}
+      {{- include "ami" $ | nindent 6 }}
       cloudInit: {}
       instanceType: {{ .Values.controlPlane.instanceType }}
       nonRootVolumes:

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -90,3 +90,15 @@ room for such suffix.
 {{- define "bastionIgnition" }}
 {{- tpl ($.Files.Get "files/bastion.iqn") . | b64enc}}
 {{- end -}}
+
+{{- define "ami" }}
+{{- if .Values.ami }}
+ami:
+  id: {{ .Values.ami }}
+{{- else -}}
+ami: {}
+imageLookupBaseOS: "ubuntu"
+imageLookupFormat: {{ "capa-ami-{{.BaseOS}}-{{.K8sVersion}}-00-gs" }}
+imageLookupOrg: "706635527432"
+{{- end }}
+{{- end -}}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -38,7 +38,7 @@ metadata:
 spec:
   availabilityZones: {{ .availabilityZones | default ( include "aws-availability-zones" .) }}
   awsLaunchTemplate:
-    ami: {}
+    {{- include "ami" $ | nindent 4 }}
     iamInstanceProfile: nodes-{{ .name }}-{{ include "resource.default.name" $ }}
     instanceType: {{ .instanceType }}
     rootVolume:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -59,6 +59,9 @@
                 }
             }
         },
+        "flatcarAWSAccount": {
+            "type": "string"
+        },
         "includeClusterResourceSet": {
             "type": "boolean"
         },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "ami": {
+            "type": "string"
+        },
         "aws": {
             "type": "object",
             "properties": {
@@ -55,9 +58,6 @@
                     "type": "integer"
                 }
             }
-        },
-        "flatcarAWSAccount": {
-            "type": "string"
         },
         "includeClusterResourceSet": {
             "type": "boolean"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -38,6 +38,7 @@ machinePools:
   - label=default
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+flatcarAWSAccount: "075585003325"
 
 # Used to override the AMI lookup and instead use a specific image
 ami: ""

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -38,7 +38,9 @@ machinePools:
   - label=default
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-flatcarAWSAccount: "075585003325"
+
+# Used to override the AMI lookup and instead use a specific image
+ami: ""
 
 # Used by `cluster-shared` library chart
 includeClusterResourceSet: true


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/1290

Makes use of the CAPA AMIs that we build ourselves.

/test create