### PR TITLE
Added network topology annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Network topology mode annotations
+
 ## [0.8.4] - 2022-08-17
 
 ### Fixed

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -4,6 +4,10 @@ kind: Cluster
 metadata:
   annotations:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+    network-topology.giantswarm.io/mode: "{{ .Values.network.topologyMode }}"
+    {{- if .Values.network.transitGatewayID }}
+    network-topology.giantswarm.io/transit-gateway: "{{ .Values.network.transitGatewayID }}"
+    {{- end}}
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" $ | nindent 4 }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -129,6 +129,12 @@
                 "serviceCIDR": {
                     "type": "string"
                 },
+                "topologyMode": {
+                    "type": "string"
+                },
+                "transitGatewayID": {
+                    "type": "null"
+                },
                 "vpcCIDR": {
                     "type": "string"
                 }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -15,6 +15,12 @@ network:
   serviceCIDR: 172.31.0.0/16
   podCIDR: 100.64.0.0/12
 
+  # topologyMode defines the type of cross-cluster networking architecture between MCs and WCs
+  # Valid values: GiantSwarmManaged, UserManaged, None
+  topologyMode: GiantSwarmManaged
+  # transitGatewayID is the ID of the TGW to use when `mode` is set to `UserManaged`.
+  transitGatewayID:
+
 bastion:
   enabled: true
   instanceType: t3.small


### PR DESCRIPTION
Initial work towards https://github.com/giantswarm/roadmap/issues/1306

Adds a value to toggle the "network topology" that the cluster will use. This will default to `GiantSwarmManaged` and but the initial focus for implementation. A `transitGatewayID` value is also added for when `UserManaged` is set.

The `network-topology.giantswarm.io/*` annotations will be used by a (currently non-existent) `transit-gateway-operator`.