### PR TITLE
bastion-add-role-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Network topology mode annotations
+- Add role label to bastion machine.
 
 ## [0.8.4] - 2022-08-17
 

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -34,6 +34,7 @@ spec:
   template:
     metadata:
       labels:
+        cluster.x-k8s.io/role: bastion
         cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
         cluster.x-k8s.io/deployment-name: {{ include "resource.default.name" $ }}-bastion
         {{- include "labels.common" $ | nindent 8 }}


### PR DESCRIPTION
needed for `dns-operator-aws` to properly find the right bastion machine, similar how we do it in gcp