### PR TITLE
make-internal-api- configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Allow configuration of loadbalancer for Control Plane API (`internal` will be default).
+- Allow configuration of loadbalancer for Control Plane API (`internet-facing` will be default).
 
 ## [0.8.6] - 2022-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow configuration of loadbalancer for Control Plane API (`internal` will be default).
+
 ## [0.8.6] - 2022-08-23
 
 ### Fixed

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -12,6 +12,8 @@ spec:
   identityRef:
     kind: AWSClusterRoleIdentity
     name: {{ .Values.aws.awsClusterRole }}
+  controlPlaneLoadBalancer:
+    scheme: {{ .Values.controlPlane.apiLoadbalancerScheme }}
   network:
     cni:
       cniIngressRules:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -42,6 +42,9 @@
         "controlPlane": {
             "type": "object",
             "properties": {
+                "apiLoadbalancerScheme": {
+                    "type": "string"
+                },
                 "containerdVolumeSizeGB": {
                     "type": "integer"
                 },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -27,6 +27,8 @@ bastion:
   replicas: 1
 
 controlPlane:
+  # can be internal or internet-facing
+  apiLoadbalancerScheme: internal
   instanceType: m5.xlarge
   rootVolumeSizeGB: 120
   etcdVolumeSizeGB: 100

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -28,7 +28,7 @@ bastion:
 
 controlPlane:
   # can be internal or internet-facing
-  apiLoadbalancerScheme: internal
+  apiLoadbalancerScheme: internet-facing
   instanceType: m5.xlarge
   rootVolumeSizeGB: 120
   etcdVolumeSizeGB: 100


### PR DESCRIPTION
in preparation for the  new private clusters