### PR TITLE
Improve hash function based on whole template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved hash function to hash based on whole `.Spec` rather than just provided values
+
 ## [0.8.6] - 2022-08-23
 
 ### Fixed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -1,3 +1,32 @@
+{{/*
+AWSMachineTemplates .Spec are immutable and cannot change.
+This function is used for both the `.Spec` value and as the data for the hash function.
+Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
+*/}}
+{{- define "controlplane-awsmachinetemplate-spec" -}}
+{{- include "ami" $  }}
+cloudInit: {}
+instanceType: {{ .Values.controlPlane.instanceType }}
+nonRootVolumes:
+- deviceName: /dev/xvdc
+  encrypted: true
+  size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
+  type: gp3
+- deviceName: /dev/xvdd
+  encrypted: true
+  size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
+  type: gp3
+- deviceName: /dev/xvde
+  encrypted: true
+  size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
+  type: gp3
+rootVolume:
+  size: {{ .Values.controlPlane.rootVolumeSizeGB }}
+  type: gp3
+iamInstanceProfile: control-plane-{{ include "resource.default.name" $ }}
+sshKeyName: ""
+{{- end }}
+
 {{- define "control-plane" }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -14,7 +43,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AWSMachineTemplate
-      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
+      name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
@@ -117,7 +146,7 @@ metadata:
   labels:
     cluster.x-k8s.io/role: control-plane
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" .Values.controlPlane "global" .) }}
+  name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:
@@ -125,26 +154,5 @@ spec:
       labels:
         cluster.x-k8s.io/role: control-plane
         {{- include "labels.common" $ | nindent 8 }}
-    spec:
-      {{- include "ami" $ | nindent 6 }}
-      cloudInit: {}
-      instanceType: {{ .Values.controlPlane.instanceType }}
-      nonRootVolumes:
-      - deviceName: /dev/xvdc
-        encrypted: true
-        size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
-        type: gp3
-      - deviceName: /dev/xvdd
-        encrypted: true
-        size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
-        type: gp3
-      - deviceName: /dev/xvde
-        encrypted: true
-        size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
-        type: gp3
-      rootVolume:
-        size: {{ .Values.controlPlane.rootVolumeSizeGB }}
-        type: gp3
-      iamInstanceProfile: control-plane-{{ include "resource.default.name" $ }}
-      sshKeyName: ""
+    spec: {{ include "bastion-awsmachinetemplate-spec" $ | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
## What this PR does / why we need it

Updates the usage of the hash function to pass in the whole template its related to, rather than just the values.

This should hopefully avoid all instances where Helm attempts to update immutable values in-place rather than recreating.

## Checklist

- [x] Update changelog in CHANGELOG.md.
