### PR TITLE
VPC and API public/private mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.Values.controlPlane.apiLoadbalancerScheme` has been removed in favour of `.Values.network.apiMode`
+
+### Added
+
+- Support for specifying private VPC configuration (not yet used)
+- Validation of vpcMode and apiMode combination being valid
+
 ## [0.9.2] - 2022-09-16
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,5 +1,5 @@
 .PHONY: template
-template:
+template: ## Output the rendered template yaml
 	@cd helm/cluster-aws && \
 		sed -i '' 's/version: \[/version: 1 #\[/' Chart.yaml && \
 		helm template . && \

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -13,7 +13,7 @@ spec:
     kind: AWSClusterRoleIdentity
     name: {{ .Values.aws.awsClusterRole }}
   controlPlaneLoadBalancer:
-    scheme: {{ .Values.controlPlane.apiLoadbalancerScheme }}
+    scheme: {{ if (eq .Values.network.apiMode "public") }}internet-facing{{ else }}internal{{ end }}
   network:
     cni:
       cniIngressRules:

--- a/helm/cluster-aws/templates/_validation.tpl
+++ b/helm/cluster-aws/templates/_validation.tpl
@@ -1,0 +1,12 @@
+{{- define "validation" }}
+{{/*
+No rendered templates live in here.
+Instead this is used to perform some validation checks on values that dont make sense elsewhere.
+*/}}
+
+{{/* Ensure that vpcMode and apiMode values are compatible with each other */}}
+{{ if and (eq .Values.network.vpcMode "private") (eq .Values.network.apiMode "public") }}
+{{- fail "`.Values.network.apiMode` cannot be 'public' if `.Values.network.vpcMode` is set to 'private'" }}
+{{ end }}
+
+{{- end -}}

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -1,3 +1,4 @@
+{{- include "validation" . }}
 ---
 {{- include "coredns" . }}
 ---

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -42,9 +42,6 @@
         "controlPlane": {
             "type": "object",
             "properties": {
-                "apiLoadbalancerScheme": {
-                    "type": "string"
-                },
                 "containerdVolumeSizeGB": {
                     "type": "integer"
                 },
@@ -123,6 +120,9 @@
         "network": {
             "type": "object",
             "properties": {
+                "apiMode": {
+                    "type": "string"
+                },
                 "availabilityZoneUsageLimit": {
                     "type": "integer"
                 },
@@ -139,6 +139,9 @@
                     "type": "string"
                 },
                 "vpcCIDR": {
+                    "type": "string"
+                },
+                "vpcMode": {
                     "type": "string"
                 }
             }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -15,6 +15,13 @@ network:
   serviceCIDR: 172.31.0.0/16
   podCIDR: 100.64.0.0/12
 
+  # vpcMode defines if the VPC is created with public, internet facing resources (public subnets, NAT gateway) or not
+  # Valid value: public, private
+  vpcMode: public
+  # apiMode defines if the Kubernetes API server load balancer should be public (internet facing) or private (internal only)
+  # Valid value: public, private
+  apiMode: public
+
   # topologyMode defines the type of cross-cluster networking architecture between MCs and WCs
   # Valid values: GiantSwarmManaged, UserManaged, None
   topologyMode: None
@@ -27,8 +34,6 @@ bastion:
   replicas: 1
 
 controlPlane:
-  # can be internal or internet-facing
-  apiLoadbalancerScheme: internet-facing
   instanceType: m5.xlarge
   rootVolumeSizeGB: 120
   etcdVolumeSizeGB: 100


### PR DESCRIPTION
### Changed

- `.Values.controlPlane.apiLoadbalancerScheme` has been removed in favour of `.Values.network.apiMode`

### Added

- Support for specifying private VPC configuration (not yet used)
- Validation of vpcMode and apiMode combination being valid

This PR also introduces a `_validation.tpl` that can be used for including value validations that don't fit elsewhere. 

Related to: https://github.com/giantswarm/roadmap/issues/1289