### PR TITLE
Pause cluster is vpcMode is private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Set `aws.giantswarm.io/vpc-mode` annotation on AWSCluster.
+- Set cluster to paused when vpcMode is set to private
 
 ## [0.10.0] - 2022-10-04
 

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -8,6 +8,9 @@ metadata:
     {{- if (eq .Values.network.dnsMode "private") }}
     aws.giantswarm.io/dns-assign-additional-vpc: "{{ .Values.network.dnsAssignAdditionalVPCs }}"
     {{- end }}
+    {{- if (eq .Values.network.vpcMode "private") }}
+    cluster.x-k8s.io/paused: "true"
+    {{end}}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -26,4 +26,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
     name: {{ include "resource.default.name" $ }}
+  {{- if (eq .Values.network.vpcMode "private") }}
+  paused: true
+  {{- end -}}
 {{- end -}}

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -18,6 +18,7 @@ network:
   # vpcMode defines if the VPC is created with public, internet facing resources (public subnets, NAT gateway) or not
   # Valid value: public, private
   vpcMode: public
+
   # apiMode defines if the Kubernetes API server load balancer should be public (internet facing) or private (internal only)
   # Valid value: public, private
   apiMode: public


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1289

Set the `Cluster` and `AWSCluster` to paused initially when `vpcMode` is set to `private`.