### PR TITLE
allow-tcp-forward-for-bastion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable tcp forwarding for sshd on bastion.
+
 ## [0.11.1] - 2022-10-14
 
 ### Fixed

--- a/helm/cluster-aws/files/etc/ssh/sshd_config_bastion
+++ b/helm/cluster-aws/files/etc/ssh/sshd_config_bastion
@@ -11,7 +11,7 @@ PasswordAuthentication no
 TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem
 MaxAuthTries 5
 LoginGraceTime 60
-AllowTcpForwarding no
+AllowTcpForwarding yes
 AllowAgentForwarding yes
 CASignatureAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
 Port 30000


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1380

necessary for nested ssh proxy commands to forwards STDIN and STDOUT