### PR TITLE
Bump 'cluster-shared' dep to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add `api-audiences` for IRSA.
+- Bump `cluster-shared` to latest
 
 ## [0.13.0] - 2022-10-19
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.3.0
-digest: sha256:4fe093f2b380650db63dc087435314bfdc33f9f4c6c3e96e4c40c3be377942f2
-generated: "2022-04-13T15:14:48.548668+01:00"
+  version: 0.6.3
+digest: sha256:ab31324bbea786b53436e44c63bbb58c2a146b3ea461a992ed81283156b5bc34
+generated: "2022-10-24T15:16:40.434987+01:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -12,5 +12,5 @@ restrictions:
     - capa
 dependencies:
 - name: cluster-shared
-  version: "0.3.0"
+  version: "0.6.3"
   repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -22,6 +22,7 @@ Common labels
 helm.sh/chart: {{ include "chart" . | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+release.giantswarm.io/version: {{ .Values.releaseVersion | quote }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -18,16 +18,21 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "labels.common" -}}
+{{- include "labels.selector" $ }}
+helm.sh/chart: {{ include "chart" . | quote }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "labels.selector" -}}
 app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.Version | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
-cluster.x-k8s.io/watch-filter: capi
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
-helm.sh/chart: {{ include "chart" . | quote }}
-release.giantswarm.io/version: {{ .Values.releaseVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -33,6 +33,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
+cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Use the latest version of `cluster-shared`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
