### PR TITLE
Skip kubeadm coredns installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `kubeadm` skip the phase where it installs `coredns` as it will be installed by as a default app.
+
 ### Fixed
 
 - Add `api-audiences` for IRSA.

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -120,6 +120,7 @@ spec:
     initConfiguration:
       skipPhases:
       - addon/kube-proxy
+      - addon/coredns
       localAPIEndpoint:
         advertiseAddress: ""
         bindPort: 0

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -1,7 +1,5 @@
 {{- include "validation" . }}
 ---
-{{- include "coredns" . }}
----
 {{- include "psps" . }}
 ---
 {{- include "cluster" . }}


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/24276

With these changes, we don't create the job that updates `coredns` manifests to adopt it as an app. Instead, we tell `kubeadm` not to deploy `coredns`, and later on, the app platform will deploy `coredns` as a default app.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
