### PR TITLE
Updating changelog entry for v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add `api-audiences` for IRSA.
-- Bump `cluster-shared` to latest
+- Add the missing `api-audiences` attribute to the `KubeadmControlPlane` template, to fix the use of IRSA service account tokens.
+
+### Changed
+
+- Update [cluster-shared](https://github.com/giantswarm/cluster-shared) from v0.3.0 to v0.6.3.
 
 ## [0.13.0] - 2022-10-19
 


### PR DESCRIPTION
### What this PR does / why we need it

Attempts to improve a changelog entry, as an example on how to make it more self-explanatory, and to establish best practices.

I'm moving the cluster-shared bump to "changed", as it's not visible which problem the update fixed.