### PR TITLE
Bumped default Kubernetes version to v1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped Kubernetes to v1.23
+
 ## [0.13.1] - 2022-10-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped Kubernetes to v1.23
 
+### Fixed
+
+- Immutable AWSMachineTemplate
+
 ## [0.13.1] - 2022-10-27
 
 ### Fixed

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -4,22 +4,28 @@ This function is used for both the `.Spec` value and as the data for the hash fu
 Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
 */}}
 {{- define "bastion-awsmachinetemplate-spec" -}}
-instanceType: {{ .Values.bastion.instanceType }}
-cloudInit:
-  insecureSkipSecretsManager: true
-imageLookupFormat: Flatcar-stable-*
-imageLookupOrg: "{{ .Values.flatcarAWSAccount }}"
-publicIP: true
-sshKeyName: ""
-subnet:
-  filters:
-  - name: tag:sigs.k8s.io/cluster-api-provider-aws/role
-    values:
-    - public
-  - name: tag:sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}
-    values:
-    - owned
-uncompressedUserData: true
+template:
+  metadata:
+    labels:
+      cluster.x-k8s.io/role: bastion
+      {{- include "labels.common" $ | nindent 6 }}
+  spec:
+    instanceType: {{ .Values.bastion.instanceType }}
+    cloudInit:
+      insecureSkipSecretsManager: true
+    imageLookupFormat: Flatcar-stable-*
+    imageLookupOrg: "{{ .Values.flatcarAWSAccount }}"
+    publicIP: true
+    sshKeyName: ""
+    subnet:
+      filters:
+      - name: tag:sigs.k8s.io/cluster-api-provider-aws/role
+        values:
+        - public
+      - name: tag:sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}
+        values:
+        - owned
+    uncompressedUserData: true
 {{- end }}
 
 {{- define "bastion" }}
@@ -82,11 +88,5 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   namespace: {{ .Release.Namespace }}
-spec:
-  template:
-    metadata:
-      labels:
-        cluster.x-k8s.io/role: bastion
-        {{- include "labels.common" $ | nindent 8 }}
-    spec: {{ include "bastion-awsmachinetemplate-spec" $ | nindent 6 }}
+spec: {{ include "bastion-awsmachinetemplate-spec" $ | nindent 2 }}
 {{- end -}}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -4,27 +4,33 @@ This function is used for both the `.Spec` value and as the data for the hash fu
 Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
 */}}
 {{- define "controlplane-awsmachinetemplate-spec" -}}
-{{- include "ami" $  }}
-cloudInit: {}
-instanceType: {{ .Values.controlPlane.instanceType }}
-nonRootVolumes:
-- deviceName: /dev/xvdc
-  encrypted: true
-  size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
-  type: gp3
-- deviceName: /dev/xvdd
-  encrypted: true
-  size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
-  type: gp3
-- deviceName: /dev/xvde
-  encrypted: true
-  size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
-  type: gp3
-rootVolume:
-  size: {{ .Values.controlPlane.rootVolumeSizeGB }}
-  type: gp3
-iamInstanceProfile: control-plane-{{ include "resource.default.name" $ }}
-sshKeyName: ""
+template:
+  metadata:
+    labels:
+      cluster.x-k8s.io/role: control-plane
+      {{- include "labels.common" $ | nindent 6 }}
+  spec:
+    {{- include "ami" $ | nindent 4 }}
+    cloudInit: {}
+    instanceType: {{ .Values.controlPlane.instanceType }}
+    nonRootVolumes:
+    - deviceName: /dev/xvdc
+      encrypted: true
+      size: {{ .Values.controlPlane.etcdVolumeSizeGB }}
+      type: gp3
+    - deviceName: /dev/xvdd
+      encrypted: true
+      size: {{ .Values.controlPlane.containerdVolumeSizeGB }}
+      type: gp3
+    - deviceName: /dev/xvde
+      encrypted: true
+      size: {{ .Values.controlPlane.kubeletVolumeSizeGB }}
+      type: gp3
+    rootVolume:
+      size: {{ .Values.controlPlane.rootVolumeSizeGB }}
+      type: gp3
+    iamInstanceProfile: control-plane-{{ include "resource.default.name" $ }}
+    sshKeyName: ""
 {{- end }}
 
 {{- define "control-plane" }}
@@ -155,11 +161,5 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   namespace: {{ $.Release.Namespace }}
-spec:
-  template:
-    metadata:
-      labels:
-        cluster.x-k8s.io/role: control-plane
-        {{- include "labels.common" $ | nindent 8 }}
-    spec: {{ include "controlplane-awsmachinetemplate-spec" $ | nindent 6 }}
+spec: {{ include "controlplane-awsmachinetemplate-spec" $ | nindent 2 }}
 {{- end -}}

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,7 +1,7 @@
 clusterName: ""  # Cluster name. Defaults to chart release name
 clusterDescription: "test"  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
-kubernetesVersion: 1.22.15
+kubernetesVersion: 1.23.13
 releaseVersion: 20.0.0-alpha1
 baseDomain: "example.com"
 


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Towards: https://github.com/giantswarm/roadmap/issues/1564

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
