### PR TITLE
Ensure version always prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the `KubeadmControlPlane` `.spec.version` value is always prefixed with `v`
+
 ## [0.13.1] - 2022-10-27
 
 ### Fixed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -145,7 +145,7 @@ spec:
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}
-  version: {{ .Values.kubernetesVersion }}
+  version: v{{ trimPrefix "v" .Values.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Ensures the version value on `KubeadmControlPlane` is always prefixed with a `v` as this value is compared to the version value in the status to work out if nodes need rolling. 
Usually this is ensured by a mutating webhook but if for whatever reason the webhook isn't called (such as we need to work around it for the skipPhases change) then this ensures the control plane isn't endlessly rolling.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
