### PR TITLE
Support setting custom node taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support setting node taints using `customNodeTaints`
+
 ## [0.14.0] - 2022-11-03
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,9 +1,9 @@
 .PHONY: template
 template: ## Output the rendered template yaml
 	@cd helm/cluster-aws && \
-		sed -i '' 's/version: \[/version: 1 #\[/' Chart.yaml && \
+		sed -i 's/version: \[/version: 1 #\[/' Chart.yaml && \
 		helm template . && \
-		sed -i '' 's/version: 1 #\[/version: \[/' Chart.yaml
+		sed -i 's/version: 1 #\[/version: \[/' Chart.yaml
 
 ensure-schema-gen:
 	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -137,12 +137,32 @@ spec:
           node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
           v: "2"
         name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
+        {{- if .Values.controlPlane.customNodeTaints }}
+        {{- if (gt (len .Values.controlPlane.customNodeTaints) 0) }}
+        taints:
+        {{- range .Values.controlPlane.customNodeTaints }}
+        - key: {{ .key | quote }}
+          value: {{ .value | quote }}
+          effect: {{ .effect | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     joinConfiguration:
       discovery: {}
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: aws
         name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
+        {{- if .Values.controlPlane.customNodeTaints }}
+        {{- if (gt (len .Values.controlPlane.customNodeTaints) 0) }}
+        taints:
+        {{- range .Values.controlPlane.customNodeTaints }}
+        - key: {{ .key | quote }}
+          value: {{ .value | quote }}
+          effect: {{ .effect | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
     preKubeadmCommands:
     {{- include "diskPreKubeadmCommands" . | nindent 4 }}
     {{- include "irsaPreKubeadmCommands" . | nindent 4 }}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -84,6 +84,16 @@ spec:
         node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ .name }},{{- join "," .customNodeLabels }}
         v: "2"
       name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
+      {{- if .customNodeTaints }}
+      {{- if (gt (len .customNodeTaints) 0) }}
+      taints:
+      {{- range .customNodeTaints }}
+      - key: {{ .key | quote }}
+        value: {{ .value | quote }}
+        effect: {{ .effect | quote }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
   postKubeadmCommands:
   {{- include "sshPostKubeadmCommands" . | nindent 2 }}
   users:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -99,6 +99,9 @@
                             "type": "string"
                         }
                     },
+                    "customNodeTaints": {
+                        "type": "array"
+                    },
                     "instanceType": {
                         "type": "string"
                     },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -60,6 +60,10 @@ machinePools:
   rootVolumeSizeGB: 300
   customNodeLabels:
   - label=default
+  customNodeTaints: []
+  # - key: ""
+  #   value: ""
+  #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 
 sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
 flatcarAWSAccount: "075585003325"


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Fixes https://github.com/giantswarm/roadmap/issues/1586

Supports setting custom taints on both worker nodes and control plane nodes. 

Note: does not allow for removing of default taints! (by design)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

No E2E cluster available yet :( 
