### PR TITLE
Handle defaults in worker pool values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle default values in worker machine pool values
+
 ## [0.14.0] - 2022-11-03
 
 ### Changed

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -50,13 +50,13 @@ spec:
   awsLaunchTemplate:
     {{- include "ami" $ | nindent 4 }}
     iamInstanceProfile: nodes-{{ .name }}-{{ include "resource.default.name" $ }}
-    instanceType: {{ .instanceType }}
+    instanceType: {{ .instanceType | default "m5.xlarge" }}
     rootVolume:
-      size: {{ .rootVolumeSizeGB }}
+      size: {{ .rootVolumeSizeGB | default 300 }}
       type: gp3
     sshKeyName: ""
-  minSize: {{ .minSize }}
-  maxSize: {{ .maxSize }}
+  minSize: {{ .minSize | default 1 }}
+  maxSize: {{ .maxSize | default 3 }}
   mixedInstancesPolicy:
     instancesDistribution:
       onDemandAllocationStrategy: prioritized


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

### What this PR does / why we need it

Ensure default values are used for workers if not provided in the values array

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

No, E2E test cluster not yet available