### PR TITLE
Make 'baseDomain' a required value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `baseDomain` a required value.
+
 ## [0.17.0] - 2022-11-18
 
 ### Added

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,1 +1,2 @@
+organization: "test"
 baseDomain: example.com

--- a/helm/cluster-aws/ci/values.yaml
+++ b/helm/cluster-aws/ci/values.yaml
@@ -1,0 +1,1 @@
+baseDomain: example.com

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -55,7 +55,7 @@ spec:
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:
-          - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
+          - "api.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
           - 127.0.0.1
         extraArgs:
           cloud-provider: aws

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -33,7 +33,7 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.organization | quote }}
+giantswarm.io/organization: {{ required "You must provide an existing organization" .Values.organization | quote }}
 cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -3,7 +3,7 @@ clusterDescription: "test"  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 kubernetesVersion: 1.23.13
 releaseVersion: 20.0.0-alpha1
-baseDomain: "example.com"
+baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
 
 aws:
   region: ""


### PR DESCRIPTION
### What this PR does / why we need it

There was a problem setting the `baseDomain` last week, and clusters kept being created relying on the default `baseDomain`, which was set to example.com. This made that the clusters were not being created successfully.

Instead, this value should be always be passed and fail if that's not the case.

I also made `organization` required to align with `cluster-gcp`.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
