### PR TITLE
Fix service account issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `https://` for IRSA service account issuer.
+
 ## [0.17.0] - 2022-11-18
 
 ### Added

--- a/helm/cluster-aws/files/opt/irsa-cloudfront.sh
+++ b/helm/cluster-aws/files/opt/irsa-cloudfront.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Replace Kubeadm Cloudfront placeholder
-CLOUDFRONT_DOMAIN=$(cat /etc/kubernetes/irsa/cloudfront-domain)
+CLOUDFRONT_DOMAIN="https://$(cat /etc/kubernetes/irsa/cloudfront-domain)"
 
 sed -i "s/PLACEHOLDER_CLOUDFRONT_DOMAIN/$CLOUDFRONT_DOMAIN/g" /run/kubeadm/kubeadm.yaml


### PR DESCRIPTION
We currently facing normalizing issuer errors when trying to use IRSA. This is because I missed the "https://" when setting the `--service-account-issuer` API flag, it needs to start with "https://" otherwise it's not working.

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
