### PR TITLE
fix IRSA placeholder replacer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add IRSA domain placeholder replacer as postKubeadm script. 
+
 ## [0.18.0] - 2022-11-24
 
 ### Added

--- a/helm/cluster-aws/files/opt/irsa-cloudfront-postkubeadm.sh
+++ b/helm/cluster-aws/files/opt/irsa-cloudfront-postkubeadm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Replace Kubeadm Cloudfront placeholder
+CLOUDFRONT_DOMAIN="https://$(cat /etc/kubernetes/irsa/cloudfront-domain)"
+
+sed -i "s|PLACEHOLDER_CLOUDFRONT_DOMAIN|$CLOUDFRONT_DOMAIN|g" /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/helm/cluster-aws/files/opt/irsa-cloudfront-postkubeadm.sh
+++ b/helm/cluster-aws/files/opt/irsa-cloudfront-postkubeadm.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Replace Kubeadm Cloudfront placeholder
-CLOUDFRONT_DOMAIN="https://$(cat /etc/kubernetes/irsa/cloudfront-domain)"
-
-sed -i "s|PLACEHOLDER_CLOUDFRONT_DOMAIN|$CLOUDFRONT_DOMAIN|g" /etc/kubernetes/manifests/kube-apiserver.yaml

--- a/helm/cluster-aws/files/opt/irsa-cloudfront.sh
+++ b/helm/cluster-aws/files/opt/irsa-cloudfront.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+if [[ ! -f "$1" ]]; then
+    exit 0
+fi
+
 # Replace Kubeadm Cloudfront placeholder
 CLOUDFRONT_DOMAIN="https://$(cat /etc/kubernetes/irsa/cloudfront-domain)"
 
-sed -i "s|PLACEHOLDER_CLOUDFRONT_DOMAIN|$CLOUDFRONT_DOMAIN|g" /run/kubeadm/kubeadm.yaml
+sed -i "s|PLACEHOLDER_CLOUDFRONT_DOMAIN|$CLOUDFRONT_DOMAIN|g" $1

--- a/helm/cluster-aws/files/opt/irsa-cloudfront.sh
+++ b/helm/cluster-aws/files/opt/irsa-cloudfront.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! -f "$1" ]]; then
+if ! [ -f "$1" ]; then
     exit 0
 fi
 

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -170,7 +170,6 @@ spec:
     preKubeadmCommands:
     {{- include "diskPreKubeadmCommands" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
-    {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
     {{- include "irsaPostKubeadmCommands" . | nindent 4 }}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -170,9 +170,10 @@ spec:
     preKubeadmCommands:
     {{- include "diskPreKubeadmCommands" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
+    {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
-    {{- include "irsaReplacerCommands" "/etc/kubernetes/manifests/kube-apiserver.yaml" | nindent 4 }}
+    {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -124,6 +124,7 @@ spec:
     {{- include "sshFiles" . | nindent 4 }}
     {{- include "diskFiles" . | nindent 4 }}
     {{- include "irsaFiles" . | nindent 4 }}
+    {{- include "irsaUpgradeFiles" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyFiles" . | nindent 4 }}{{- end }}
     {{- include "kubernetesFiles" . | nindent 4 }}
     initConfiguration:
@@ -172,6 +173,8 @@ spec:
     {{- include "irsaPreKubeadmCommands" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
+    postKubeadmCommands:
+    {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -124,7 +124,6 @@ spec:
     {{- include "sshFiles" . | nindent 4 }}
     {{- include "diskFiles" . | nindent 4 }}
     {{- include "irsaFiles" . | nindent 4 }}
-    {{- include "irsaUpgradeFiles" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyFiles" . | nindent 4 }}{{- end }}
     {{- include "kubernetesFiles" . | nindent 4 }}
     initConfiguration:
@@ -170,11 +169,10 @@ spec:
         {{- end }}
     preKubeadmCommands:
     {{- include "diskPreKubeadmCommands" . | nindent 4 }}
-    {{- include "irsaPreKubeadmCommands" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
     {{- if .Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
-    {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
+    {{- include "irsaReplacerCommands" "/etc/kubernetes/manifests/kube-apiserver.yaml" | nindent 4 }}
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -94,6 +94,13 @@ room for such suffix.
   content: {{ $.Files.Get "files/opt/irsa-cloudfront.sh" | b64enc }}
 {{- end -}}
 
+{{- define "irsaUpgradeFiles" -}}
+- path: /opt/irsa-cloudfront-postkubeadm.sh
+  permissions: "0700"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/irsa-cloudfront-postkubeadm.sh" | b64enc }}
+{{- end -}}
+
 {{- define "kubernetesFiles" -}}
 - path: /etc/kubernetes/policies/audit-policy.yaml
   permissions: "0600"
@@ -124,6 +131,10 @@ room for such suffix.
 
 {{- define "irsaPreKubeadmCommands" -}}
 - /bin/sh /opt/irsa-cloudfront.sh
+{{- end -}}
+
+{{- define "irsaPostKubeadmCommands" -}}
+- /bin/sh /opt/irsa-cloudfront-postkubeadm.sh
 {{- end -}}
 
 {{- define "sshUsers" -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -126,10 +126,6 @@ room for such suffix.
 - /bin/sh /opt/irsa-cloudfront.sh
 {{- end -}}
 
-{{- define "irsaPostKubeadmCommands" -}}
-- /bin/sh /opt/irsa-cloudfront-postkubeadm.sh
-{{- end -}}
-
 {{- define "sshUsers" -}}
 - name: giantswarm
   groups: sudo

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -94,13 +94,6 @@ room for such suffix.
   content: {{ $.Files.Get "files/opt/irsa-cloudfront.sh" | b64enc }}
 {{- end -}}
 
-{{- define "irsaUpgradeFiles" -}}
-- path: /opt/irsa-cloudfront-postkubeadm.sh
-  permissions: "0700"
-  encoding: base64
-  content: {{ $.Files.Get "files/opt/irsa-cloudfront-postkubeadm.sh" | b64enc }}
-{{- end -}}
-
 {{- define "kubernetesFiles" -}}
 - path: /etc/kubernetes/policies/audit-policy.yaml
   permissions: "0600"
@@ -129,7 +122,7 @@ room for such suffix.
 - /bin/sh /opt/init-disks.sh
 {{- end -}}
 
-{{- define "irsaPreKubeadmCommands" -}}
+{{- define "irsaReplacerCommands" -}}
 - /bin/sh /opt/irsa-cloudfront.sh
 {{- end -}}
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -140,10 +140,6 @@ room for such suffix.
 - /bin/sh /opt/init-disks.sh
 {{- end -}}
 
-{{- define "irsaPreKubeadmCommands" -}}
-- /bin/sh /opt/irsa-cloudfront.sh /run/kubeadm/kubeadm.yaml
-{{- end -}}
-
 {{- define "irsaPostKubeadmCommands" -}}
 - /bin/sh /opt/irsa-cloudfront.sh /etc/kubernetes/manifests/kube-apiserver.yaml
 {{- end -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -122,8 +122,12 @@ room for such suffix.
 - /bin/sh /opt/init-disks.sh
 {{- end -}}
 
-{{- define "irsaReplacerCommands" -}}
-- /bin/sh /opt/irsa-cloudfront.sh
+{{- define "irsaPreKubeadmCommands" -}}
+- /bin/sh /opt/irsa-cloudfront.sh /run/kubeadm/kubeadm.yaml
+{{- end -}}
+
+{{- define "irsaPostKubeadmCommands" -}}
+- /bin/sh /opt/irsa-cloudfront.sh /etc/kubernetes/manifests/kube-apiserver.yaml
 {{- end -}}
 
 {{- define "sshUsers" -}}


### PR DESCRIPTION
### What this PR does / why we need it

At the moment, CAPA cluster upgrades require manuel intervention due to service-account-issuer placeholder is not replaced on non-init nodes. This PR enables replacing of the placeholder on non-init nodes.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
