### PR TITLE
fix-etcd-listen-ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change etcd metric listen  ip to a node ip instead of `0.0.0.0`.
+
 ## [0.19.0] - 2022-11-29
 
 ### Add

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -105,18 +105,18 @@ spec:
       controllerManager:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
-          bind-address: 0.0.0.0
+          bind-address: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
           cloud-provider: aws
           allocate-node-cidrs: "true"
           cluster-cidr: {{ .Values.network.podCIDR }}
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
-          bind-address: 0.0.0.0
+          bind-address: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
       etcd:
         local:
           extraArgs:
-            listen-metrics-urls: "http://0.0.0.0:2381"
+            listen-metrics-urls: http://'{{ `{{ ds.meta_data.local_ipv4 }}` }}':2381
             quota-backend-bytes: "8589934592"
       networking:
         serviceSubnet: {{ .Values.network.serviceCIDR }}


### PR DESCRIPTION
bind to a node IP, instead of binding to `0.0.0.0` because than the `kubeadm` is using that IP to set the health probe and   you cannot connect to 0.0.0.0