### PR TITLE
Specify missing array items schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add schema for items of the arrays `.machinePools[*].availabilityZones` and `.machinePools[*].customNodeTaints`.
+
 ## [0.19.0] - 2022-11-29
 
-### Add
+### Added
 
 - Add option to specify oidc CA PEM in order to autheticate againts OIDC with custom CA.
 - Add option to configure containerd registry authentication for `docker.io`.

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -108,7 +108,12 @@
                             "type": "object",
                             "properties": {
                                 "effect": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "NoSchedule",
+                                        "PreferNoSchedule",
+                                        "NoExecute"
+                                    ]
                                 },
                                 "key": {
                                     "type": "string"

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -91,7 +91,10 @@
                 "type": "object",
                 "properties": {
                     "availabilityZones": {
-                        "type": "array"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "customNodeLabels": {
                         "type": "array",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -103,7 +103,26 @@
                         }
                     },
                     "customNodeTaints": {
-                        "type": "array"
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "effect": {
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "effect",
+                                "key",
+                                "value"
+                            ]
+                        }
                     },
                     "instanceType": {
                         "type": "string"


### PR DESCRIPTION
### What this PR does / why we need it

This adds the schema for items of these two arrays:

- `.machinePools[*].availabilityZones`
- `.machinePools[*].customNodeTaints`

This is required for proper validation and generating a data entry form for this app (towards https://github.com/giantswarm/roadmap/issues/1181)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
