### PR TITLE
add-base-domain-to-no-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cluster base domain to no proxy config.
+
 ## [0.20.2] - 2022-12-09
 
 ### Changed

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -86,10 +86,10 @@ room for such suffix.
 {{- define "proxyCommand" -}}
 - export HTTP_PROXY={{ $.Values.proxy.http_proxy }}
 - export HTTPS_PROXY={{ $.Values.proxy.https_proxy }}
-- export NO_PROXY=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},elb.amazonaws.com
+- export NO_PROXY=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com
 - export http_proxy={{ $.Values.proxy.http_proxy }}
 - export https_proxy={{ $.Values.proxy.https_proxy }}
-- export no_proxy=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},elb.amazonaws.com
+- export no_proxy=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com
 - systemctl daemon-reload
 - systemctl restart containerd
 - systemctl restart kubelet


### PR DESCRIPTION
with OIDC SSO  - k8s api is connecting to dex.CLUSTER.BASEDOMAIN if this is not in `no-proxy` then it will go thru a proxy which is not allowed in a private environment