### PR TITLE
Deprecate confusingly named `aws.awsClusterRole` in favor of `aws.awsClusterRoleIdentityName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change default NTP server as AWS NTP server.
+- Deprecate confusingly named `aws.awsClusterRole` in favor of `aws.awsClusterRoleIdentityName`. The value refers to an `AWSClusterRoleIdentity` object, not directly to an IAM role name/ARN.
 
 ## [0.20.3] - 2022-12-22
 
@@ -32,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add schema for items of the arrays `.machinePools[*].availabilityZones` and `.machinePools[*].customNodeTaints`.
-- Add IRSA domain placeholder replacer as postKubeadm script. 
+- Add IRSA domain placeholder replacer as postKubeadm script.
 - Add `containerd` registry auth workaround to bug https://github.com/giantswarm/roadmap/issues/1737.
 
 ## [0.19.0] - 2022-11-29

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -21,7 +21,7 @@ spec:
     enabled: false
   identityRef:
     kind: AWSClusterRoleIdentity
-    name: {{ .Values.aws.awsClusterRole }}
+    name: {{ if .Values.aws.awsClusterRole }}{{ .Values.aws.awsClusterRole }}{{ else }}{{ .Values.aws.awsClusterRoleIdentityName }}{{ end }}
   controlPlaneLoadBalancer:
     scheme: {{ if (eq .Values.network.apiMode "public") }}internet-facing{{ else }}internal{{ end }}
   network:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -9,7 +9,14 @@
             "type": "object",
             "properties": {
                 "awsClusterRole": {
-                    "type": "string"
+                    "type": "string",
+                    "deprecated": true
+                },
+                "awsClusterRoleIdentityName": {
+                    "type": "string",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$"
                 },
                 "region": {
                     "type": "string"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -7,7 +7,12 @@ baseDomain: ""  # Customer base domain, generally of the form "<customer codenam
 
 aws:
   region: ""
-  awsClusterRole: "default"
+  # awsClusterRoleIdentityName is the name of an `AWSClusterRoleIdentity` object. This in turn refers to the IAM role used to
+  # create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create
+  # all resources in that account. The value of `awsClusterRoleIdentityName` does not refer directly to an IAM role name/ARN!
+  # See also https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html#awsclusterroleidentity.
+  awsClusterRoleIdentityName: "default"
+  awsClusterRole: ""  # deprecated, please use `awsClusterRoleIdentityName`
 
 network:
   availabilityZoneUsageLimit: 3  # amount of AZ that should be used for the machines


### PR DESCRIPTION
### What this PR does / why we need it

The name was confusing. The value doesn't point to a role name or ARN, but to an `AWSClusterRoleIdentity` object in the cluster. In order to avoid human mistakes, the JSON schema now disallows `:` (as seen in IAM role ARNs).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
