### PR TITLE
Bump Kubernetes to 1.23.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change default NTP server as AWS NTP server.
+- Bump Kubernetes to 1.23.15
 
 ## [0.20.3] - 2022-12-22
 

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,7 +1,7 @@
 clusterName: ""  # Cluster name. Defaults to chart release name
 clusterDescription: "test"  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
-kubernetesVersion: 1.23.13
+kubernetesVersion: 1.23.15
 releaseVersion: 20.0.0-alpha1
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
 


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/1669.

Tested by creating a workload cluster with that version, checking kubelet + system pod health and logs, and by trying a simple application (echo server behind ingress). The official [Kubernetes changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v12315) also does not show any major changes to look out for.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
