### PR TITLE
Override image repository because kubeadm of Kubernetes v1.23.15 tries to pull the official image incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Override image repository to `registry.k8s.io` because kubeadm of Kubernetes v1.23.15 tries to pull the official image incorrectly, resulting in failing cluster upgrades, and `k8s.gcr.io` is outdated
+
 ## [0.20.4] - 2023-01-05
 
 ### Changed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -52,6 +52,7 @@ spec:
       name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
+      imageRepository: registry.k8s.io {{- /* Temporary so that `kubeadm join` keeps working (https://github.com/giantswarm/roadmap/issues/1669, https://github.com/kubernetes/kubernetes/pull/114978), will later be replaced by Giant Swarm repo via https://github.com/giantswarm/roadmap/issues/1722 */}}
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:


### PR DESCRIPTION
### What this PR does / why we need it

While kubeadm is buggy (https://github.com/kubernetes/kubernetes/pull/114978) and tries to download the CoreDNS image despite us skipping that addon (https://github.com/kubernetes/kubeadm/issues/2603), we try to use the new official repository already. This fixes `kubeadm join` for new Kubernetes versions and therefore avoids stuck node upgrades. CAPI propagates the value of `clusterConfiguration.imageRepository` before attempting the node upgrade (but doesn't propagate `clusterConfiguration.dns.imageRepository` so we can't make this a CoreDNS-scoped change).

This would then happen on upgrade:

- Existing CAPI-managed cluster with Kubernetes < v1.23.15 (older version of cluster-aws)
- cluster-aws version upgrade changes the `KubeadmControlPlane` manifest, setting both a higher Kubernetes version and the new image repository at once
- CAPI propagates the desired image repository value and then starts the rollout (see [upgrade logic](https://github.com/kubernetes-sigs/cluster-api/blob/v1.2.4/controlplane/kubeadm/internal/controllers/upgrade.go))

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
