### PR TITLE
Included an option to add harbor registry to registry-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ## Breaking Change
 
-- Restructured `registry.password` and `registry.username` to `registry.dockerRegistry.password` and `registry.dockerRegistry.username`
+- Replaced `registry` parameter  to `connectivity.containerRegistries` in the values schema
 
 ### Added
-- Included harbor registry config to regsitry-config.toml as a mirror for "docker.io" host
-- Add `registry.harborRegistry.url`,  `registry.harborRegistry.password` and `registry.harborRegistry.username` to accomodate harbor regsitry configuration
+
+- Made registry configurations `connectivity.containerRegistries` dynamic to accept as many container registries and mirrors as needed
 
 ## [0.23.0] - 2023-02-01
 
 ### Added
 
 - Add value to specify which AWS account ID to use when associating Route53 Resolver Rules with workload cluster VPC.
-
 
 ## [0.22.0] - 2023-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Breaking Change
+
+- Restructured `registry.password` and `registry.username` to `registry.dockerRegistry.password` and `registry.dockerRegistry.username`
+
+### Added
+- Included harbor registry config to regsitry-config.toml as a mirror for "docker.io" host
+- Add `registry.harborRegistry.url`,  `registry.harborRegistry.password` and `registry.harborRegistry.username` to accomodate harbor regsitry configuration
+
 ## [0.22.0] - 2023-01-24
 
 ### Changed

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -14,11 +14,11 @@
       {{ with $value.credentials -}}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
       {{ if and .username .password -}}
-      auth := {{ printf "%s:%s" .username .password | b64enc | quote }}
+      auth = {{ printf "%s:%s" .username .password | b64enc | quote }}
       {{- else if .auth -}}
       auth = {{ .auth | quote }}
       {{ else if .identitytoken -}}
-      identitytoken := {{ .identitytoken  | quote }}
+      identitytoken = {{ .identitytoken  | quote }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -2,16 +2,16 @@
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
-        {{- if and .Values.configure .Values.registry.harborRegistry -}}
+        {{- if and .Values.registry.configure .Values.registry.harborRegistry -}}
         {{ include "fullurl" . | quote }},
         {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
-    {{ if and .Values.configure .Values.registry.dockerRegistry -}}
+    {{ if and .Values.registry.configure .Values.registry.dockerRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.dockerRegistry.username }}:{{ .Values.registry.dockerRegistry.password }}" . | b64enc }}"
     {{ end -}}
-    {{ if and .Values.configure .Values.registry.harborRegistry -}}
+    {{ if and .Values.registry.configure .Values.registry.harborRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.registry.harborRegistry.url -}}".auth]
       auth = "{{ tpl "{{ .Values.registry.harborRegistry.username }}:{{ .Values.registry.harborRegistry.password }}" . | b64enc }}"
     {{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        {{- printf "https://%s" .Values.harborRegistry.url | quote -}},
+        {{ include "fullurl" . | quote }},
         {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,8 +3,9 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        {{- printf "https://%s" .Values.harborRegistry.url | quote -}}
-        {{- end -}}, "https://registry-1.docker.io", "giantswarm.azurecr.io"]
+        {{- printf "https://%s" .Values.harborRegistry.url | quote -}},
+        {{- end -}}
+        "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ harborRegistry.fullurl }}"
+        "{{ harborRegistryFullurl }}"
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -9,7 +9,7 @@
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
-    {{- if .Values.harborRegistry -}}
+    {{ if .Values.harborRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.harborRegistry.url -}}".auth]
       auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
     {{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,8 +3,8 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ harborRegistry.fullurl }}",
-        {{- end -}}
+        "{{ harborRegistry.fullurl }}"
+        {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -1,7 +1,15 @@
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+{{- if .Values.harborRegistry -}}
+      endpoint = ["{{ .Values.harborRegistry.username }}"", "https://registry-1.docker.io", "giantswarm.azurecr.io"]
+{{- else -}}
       endpoint = ["https://registry-1.docker.io", "giantswarm.azurecr.io"]
+{{- end -}}
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
+    {{- if .Values.harborRegistry -}}
+    [plugins."io.containerd.grpc.v1.cri".registry.configs.{{ .Values.harborRegistry.url}}.auth]
+      auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
+    {{- end -}}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -5,7 +5,5 @@
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
-    {{- if .Values.harborRegistry -}}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .Values.harborRegistry.url }}".auth]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."core.harbor.g8s.gauss.eu-west-1.aws.gigantic.io".auth]
       auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
-    {{- end -}}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -1,15 +1,11 @@
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-{{- if .Values.harborRegistry -}}
-      endpoint = ["{{ .Values.harborRegistry.username }}"", "https://registry-1.docker.io", "giantswarm.azurecr.io"]
-{{- else -}}
-      endpoint = ["https://registry-1.docker.io", "giantswarm.azurecr.io"]
-{{- end -}}
+      endpoint = ["https://core.harbor.g8s.gauss.eu-west-1.aws.gigantic.io", "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
     {{- if .Values.harborRegistry -}}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs.{{ .Values.harborRegistry.url}}.auth]
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .Values.harborRegistry.url }}".auth]
       auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
     {{- end -}}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -7,9 +7,11 @@
         {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
+    {{ if and .Values.configure .Values.registry.dockerRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.dockerRegistry.username }}:{{ .Values.registry.dockerRegistry.password }}" . | b64enc }}"
-    {{ if .Values.registry.harborRegistry -}}
+    {{ end -}}
+    {{ if and .Values.configure .Values.registry.harborRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.registry.harborRegistry.url -}}".auth]
       auth = "{{ tpl "{{ .Values.registry.harborRegistry.username }}:{{ .Values.registry.harborRegistry.password }}" . | b64enc }}"
     {{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ include fullurl }}"
+        "{{ include fullurl . }}"
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ include harborRegistry.fullurl }}"
+        "{{ include fullurl }}"
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -2,14 +2,14 @@
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
-        {{- if .Values.harborRegistry -}}
+        {{- if .Values.registry.harborRegistry -}}
         {{ include "fullurl" . | quote }},
         {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
-    {{ if .Values.harborRegistry -}}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.harborRegistry.url -}}".auth]
-      auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
+    {{ if .Values.registry.harborRegistry -}}
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.registry.harborRegistry.url -}}".auth]
+      auth = "{{ tpl "{{ .Values.registry.harborRegistry.username }}:{{ .Values.registry.harborRegistry.password }}" . | b64enc }}"
     {{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -1,17 +1,25 @@
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
-        {{- if and .Values.registry.configure .Values.registry.harborRegistry -}}
-        {{ include "fullurl" . | quote }},
+        {{- range $value := $config -}}
+        "https://{{$value.endpoint}}",
         {{- end -}}
-        "https://registry-1.docker.io", "giantswarm.azurecr.io"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs]
-    {{ if and .Values.registry.configure .Values.registry.dockerRegistry -}}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
-      auth = "{{ tpl "{{ .Values.registry.dockerRegistry.username }}:{{ .Values.registry.dockerRegistry.password }}" . | b64enc }}"
-    {{ end -}}
-    {{ if and .Values.registry.configure .Values.registry.harborRegistry -}}
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.registry.harborRegistry.url -}}".auth]
-      auth = "{{ tpl "{{ .Values.registry.harborRegistry.username }}:{{ .Values.registry.harborRegistry.password }}" . | b64enc }}"
+    ]
+  {{- end }}
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+    {{ range $value := $config -}}
+      {{ with $value.credentials -}}
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
+      {{ if and .username .password -}}
+      auth := {{ printf "%s:%s" .username .password | b64enc | quote }}
+      {{- else if .auth -}}
+      auth = {{ .auth | quote }}
+      {{ else if .identitytoken -}}
+      identitytoken := {{ .identitytoken  | quote }}
+      {{- end }}
     {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ harborRegistryFullurl }}"
+        "{{ include harborRegistry.fullurl }}"
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -2,13 +2,13 @@
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
-        {{- if .Values.registry.harborRegistry -}}
+        {{- if and .Values.configure .Values.registry.harborRegistry -}}
         {{ include "fullurl" . | quote }},
         {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
-      auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
+      auth = "{{ tpl "{{ .Values.registry.dockerRegistry.username }}:{{ .Values.registry.dockerRegistry.password }}" . | b64enc }}"
     {{ if .Values.registry.harborRegistry -}}
     [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.registry.harborRegistry.url -}}".auth]
       auth = "{{ tpl "{{ .Values.registry.harborRegistry.username }}:{{ .Values.registry.harborRegistry.password }}" . | b64enc }}"

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ include fullurl . }}"
+        {{ include fullurl . | quote }}
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,8 +3,8 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        "{{ .Values.harborRegistry.url }}",
-        {{- end }}
+        "{{ harborRegistry.fullurl }}",
+        {{- end -}}
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,7 +3,7 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        {{ include fullurl . | quote }}
+        {{- printf "https://%s" .Values.harborRegistry.url -}}
         {{- end -}},
         "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -3,9 +3,8 @@
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = [
         {{- if .Values.harborRegistry -}}
-        {{- printf "https://%s" .Values.harborRegistry.url -}}
-        {{- end -}},
-        "https://registry-1.docker.io", "giantswarm.azurecr.io"]
+        {{- printf "https://%s" .Values.harborRegistry.url | quote -}}
+        {{- end -}}, "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"

--- a/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
+++ b/helm/cluster-aws/files/etc/containerd/conf.d/registry-config.toml
@@ -1,9 +1,15 @@
 [plugins."io.containerd.grpc.v1.cri".registry]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-      endpoint = ["https://core.harbor.g8s.gauss.eu-west-1.aws.gigantic.io", "https://registry-1.docker.io", "giantswarm.azurecr.io"]
+      endpoint = [
+        {{- if .Values.harborRegistry -}}
+        "{{ .Values.harborRegistry.url }}",
+        {{- end }}
+        "https://registry-1.docker.io", "giantswarm.azurecr.io"]
   [plugins."io.containerd.grpc.v1.cri".registry.configs]
     [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
       auth = "{{ tpl "{{ .Values.registry.username }}:{{ .Values.registry.password }}" . | b64enc }}"
-    [plugins."io.containerd.grpc.v1.cri".registry.configs."core.harbor.g8s.gauss.eu-west-1.aws.gigantic.io".auth]
+    {{- if .Values.harborRegistry -}}
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{- .Values.harborRegistry.url -}}".auth]
       auth = "{{ tpl "{{ .Values.harborRegistry.username }}:{{ .Values.harborRegistry.password }}" . | b64enc }}"
+    {{- end }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,6 +107,12 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
+{{- if .Values.harborRegistry -}}
+{{- define harborRegistry.fullurl -}}
+"https://{{ .Values.harborRegistry.url }}"
+{{- end -}}
+{{- end -}}
+
 {{- define "irsaFiles" -}}
 - path: /opt/irsa-cloudfront.sh
   permissions: "0700"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -96,16 +96,12 @@ room for such suffix.
 {{- end -}}
 
 {{- define "registryFiles" -}}
-{{- if .Values.registry -}}
-{{- if .Values.registry.configure -}}
 - path: /etc/containerd/conf.d/registry-config.toml
   permissions: "0600"
   contentFrom:
     secret:
       name: {{ include "resource.default.name" $ }}-registry-configuration
       key: registry-config.toml
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- define "irsaFiles" -}}
 - path: /opt/irsa-cloudfront.sh

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,11 +107,6 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "fullurl" -}}
-{{- printf "https://%s" .Values.registry.harborRegistry.url -}}
-{{- end -}}
-
 {{- define "irsaFiles" -}}
 - path: /opt/irsa-cloudfront.sh
   permissions: "0700"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,7 +107,7 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- define harborRegistry.fullurl -}}
+{{- define "harborRegistry.fullurl" -}}
 "https://{{ .Values.harborRegistry.url }}"
 {{- end -}}
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,8 +107,8 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- define "harborRegistryFullurl" -}}
-"https://{{ .Values.harborRegistry.url }}"
+{{- define "harborRegistry.fullurl" -}}
+{{- printf "https://%s" .Values.harborRegistry.url -}}
 {{- end -}}
 
 {{- define "irsaFiles" -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,6 +107,10 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
+{{- define "fullurl" -}}
+{{- printf "https://%s" .Values.harborRegistry.url -}}
+{{- end -}}
+
 {{- define "irsaFiles" -}}
 - path: /opt/irsa-cloudfront.sh
   permissions: "0700"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -94,6 +94,7 @@ room for such suffix.
 - systemctl restart containerd
 - systemctl restart kubelet
 {{- end -}}
+
 {{- define "registryFiles" -}}
 {{- if .Values.registry -}}
 {{- if .Values.registry.configure -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,7 +107,7 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- define "harborRegistry.fullurl" -}}
+{{- define "harborRegistryFullurl" -}}
 "https://{{ .Values.harborRegistry.url }}"
 {{- end -}}
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,10 +107,8 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- if .Values.harborRegistry -}}
 {{- define harborRegistry.fullurl -}}
 "https://{{ .Values.harborRegistry.url }}"
-{{- end -}}
 {{- end -}}
 
 {{- define "irsaFiles" -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,7 +107,7 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- define "harborRegistry.fullurl" -}}
+{{- define "fullurl" -}}
 {{- printf "https://%s" .Values.harborRegistry.url -}}
 {{- end -}}
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -108,7 +108,7 @@ room for such suffix.
 {{- end -}}
 
 {{- define "fullurl" -}}
-{{- printf "https://%s" .Values.harborRegistry.url -}}
+{{- printf "https://%s" .Values.registry.harborRegistry.url -}}
 {{- end -}}
 
 {{- define "irsaFiles" -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -107,10 +107,6 @@ room for such suffix.
 {{- end -}}
 {{- end -}}
 
-{{- define "fullurl" -}}
-{{- printf "https://%s" .Values.harborRegistry.url -}}
-{{- end -}}
-
 {{- define "irsaFiles" -}}
 - path: /opt/irsa-cloudfront.sh
   permissions: "0700"

--- a/helm/cluster-aws/templates/_registry-secret.yaml
+++ b/helm/cluster-aws/templates/_registry-secret.yaml
@@ -1,4 +1,4 @@
-{{- define "registry-secret" -}}
+{{- define "registry-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/cluster-aws/templates/_registry-secret.yaml
+++ b/helm/cluster-aws/templates/_registry-secret.yaml
@@ -1,12 +1,8 @@
 {{- define "registry-secret" -}}
-{{- if .Values.registry -}}
-{{- if .Values.registry.configure -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "resource.default.name" $ }}-registry-configuration
 data:
   registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/conf.d/registry-config.toml") $ | b64enc | quote }}
-{{- end -}}
-{{- end -}}
 {{- end -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -255,19 +255,19 @@
                 "username": {
                     "type": "string"
                 }
-            }
-        },
-        "harborRegistry": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
+            },
+            "harborRegistry": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -254,6 +254,20 @@
                 }
             }
         },
+        "harborRegistry": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "releaseVersion": {
             "type": "string"
         },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -52,6 +52,14 @@
         "clusterName": {
             "type": "string"
         },
+        "connectivity": {
+            "type": "object",
+            "properties": {
+                "containerRegistries": {
+                    "type": "object"
+                }
+            }
+        },
         "controlPlane": {
             "type": "object",
             "properties": {
@@ -273,41 +281,8 @@
                 "https_proxy": {
                     "type": "string"
                 },
-		"no_proxy": {
+                "no_proxy": {
                     "type": "string"
-                }
-            }
-        },
-        "registry": {
-            "type": "object",
-            "properties": {
-                "configure": {
-                    "type": "boolean"
-                },
-                "dockerRegistry": {
-                    "type": "object",
-                    "properties": {
-                        "password": {
-                            "type": "string"
-                        },
-                        "username": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "harborRegistry": {
-                    "type": "object",
-                    "properties": {
-                        "password": {
-                            "type": "string"
-                        },
-                        "url": {
-                            "type": "string"
-                        },
-                        "username": {
-                            "type": "string"
-                        }
-                    }
                 }
             }
         },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -249,24 +249,29 @@
                 "configure": {
                     "type": "boolean"
                 },
-                "password": {
-                    "type": "string"
+                "dockerRegistry": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    }
                 },
-                "username": {
-                    "type": "string"
-                }
-            },
-            "harborRegistry": {
-                "type": "object",
-                "properties": {
-                    "url": {
-                        "type": "string"
-                    },
-                    "password": {
-                        "type": "string"
-                    },
-                    "username": {
-                        "type": "string"
+                "harborRegistry": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -106,3 +106,9 @@ kubectlImage:
 # Used to force-recreate resources that use a hash suffix in their name.
 # To use, set this to a random string to trigger new hash values to be generated.
 hashSalt: ""
+
+registry:
+  harborRegistry:
+    url: core.harbor.grizzly.eu-west-1.aws.gigantic.io
+    password: Harbor12345
+    username: admin

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -106,4 +106,3 @@ kubectlImage:
 # Used to force-recreate resources that use a hash suffix in their name.
 # To use, set this to a random string to trigger new hash values to be generated.
 hashSalt: ""
-

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -137,3 +137,15 @@ kubectlImage:
 # Used to force-recreate resources that use a hash suffix in their name.
 # To use, set this to a random string to trigger new hash values to be generated.
 hashSalt: ""
+
+connectivity:
+  containerRegistries: {}
+#   docker.io:
+#   - endpoint: "registry-1.docker.io"
+#     credentials:
+#       username: ""
+#       password: ""
+#   - endpoint: "my-mirror-registry.mydomain.io"
+#     credentials:
+#       auth: ""
+#       identitytoken: ""

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -107,8 +107,3 @@ kubectlImage:
 # To use, set this to a random string to trigger new hash values to be generated.
 hashSalt: ""
 
-registry:
-  harborRegistry:
-    url: core.harbor.grizzly.eu-west-1.aws.gigantic.io
-    password: Harbor12345
-    username: admin


### PR DESCRIPTION
Co-authored-by: William Young <will.young@engineerbetter.com>

### What this PR does / why we need it
- Restructured `.Values.registry` to accommodate configuration for docker and Harbor registries this is to enable us to be able to add a private Harbor registry as a mirror for docker in containerd

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
