### PR TITLE
Use Giant Swarm image repository for official Kubernetes images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use Giant Swarm image repository for official Kubernetes images
+
 ## [0.20.5] - 2023-01-11
 
 ### Changed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -52,7 +52,9 @@ spec:
       name: {{ include "resource.default.name" $ }}-control-plane-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: registry.k8s.io {{- /* Temporary so that `kubeadm join` keeps working (https://github.com/giantswarm/roadmap/issues/1669, https://github.com/kubernetes/kubernetes/pull/114978), will later be replaced by Giant Swarm repo via https://github.com/giantswarm/roadmap/issues/1722 */}}
+      # Avoid accessibility issues (e.g. on private clusters) and potential future rate limits for the default `registry.k8s.io`
+      imageRepository: docker.io/giantswarm
+
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/1722.

Official Kubernetes images were previously still pulled from upstream repos such as `k8s.gcr.io` (deprecated) and `registry.k8s.io`. Private clusters may not want to open access to them, and in general we use our own image hosting (e.g. Docker Hub, Quay) to remain reliable. The switch to Docker Hub requires that clusters have working Docker Hub credentials, or else will soon run into their drastic rate limits for anonymous image pulls.

As prerequisite, I had changed retagger to mirror the needed images (https://github.com/giantswarm/retagger/pull/780). Mind https://github.com/kubernetes/kubeadm/issues/2603 which can make the `coredns` image mirroring unnecessary in the future.

I successfully tested on `golem` whether the node rollout works using the new `imageRepository` value.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
