### PR TITLE
Remove unused `releaseVersion` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fail in Helm template if `dnsMode=public` is combined with a `baseDomain` ending with `.internal`
+- Fail in Helm template if `dnsMode=public` is combined with a `baseDomain` ending with `.internal`.
+
+### Removed
+
+- Remove unused `releaseVersion` setting from `values.yaml`.
 
 ## [0.25.1] - 2023-02-16
 
@@ -25,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 
-- Replaced `registry` parameter  to `connectivity.containerRegistries` in the values schema
+- Replaced `registry` parameter  to `connectivity.containerRegistries` in the values schema.
 
 ### Fixed
 
@@ -33,8 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Made registry configurations `connectivity.containerRegistries` dynamic to accept as many container registries and mirrors as needed
-- Expose helm value for customers to decide whether or not VPC endpoint should be created by Giantswarm.
+- Made registry configurations `connectivity.containerRegistries` dynamic to accept as many container registries and mirrors as needed.
+- Expose helm value for customers to decide whether VPC endpoint should be created by Giantswarm.
 
 ### Changed
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -22,7 +22,6 @@ Common labels
 helm.sh/chart: {{ include "chart" . | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
-release.giantswarm.io/version: {{ .Values.releaseVersion | quote }}
 {{- end -}}
 
 {{/*

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -272,9 +272,6 @@
                 }
             }
         },
-        "releaseVersion": {
-            "type": "string"
-        },
         "sshSSOPublicKey": {
             "type": "string"
         }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -2,7 +2,6 @@ clusterName: ""  # Cluster name. Defaults to chart release name
 clusterDescription: "test"  # Cluster description used in metadata.
 organization: ""  # Organization in which to create the cluster.
 kubernetesVersion: 1.23.16
-releaseVersion: 20.0.0-alpha1
 baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
 
 aws:


### PR DESCRIPTION
### What this PR does / why we need it

Remove unused `releaseVersion` setting from `values.yaml`. It was set for compatibility reasons to have CAPI and Vintage releases on Vintage MCs, but `v20.0.0-alpha1` is now removed.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
