### PR TITLE
Add value to specify AWS Account to use when associating resolver rules with WC VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add value to specify which AWS account ID to use when associating Route53 Resolver Rules with workload cluster VPC.
+
 ## [0.22.0] - 2023-01-24
 
 ### Changed

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -8,6 +8,9 @@ metadata:
     {{- if (eq .Values.network.dnsMode "private") }}
     aws.giantswarm.io/dns-assign-additional-vpc: "{{ .Values.network.dnsAssignAdditionalVPCs }}"
     {{- end }}
+    {{- if .Values.network.resolverRulesOwnerAccount }}
+    aws.giantswarm.io/resolver-rules-owner-account: "{{ .Values.network.resolverRulesOwnerAccount }}"
+    {{- end}}
     {{- if (eq .Values.network.vpcMode "private") }}
     cluster.x-k8s.io/paused: "true"
     {{end}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -193,6 +193,17 @@
                 "prefixListID": {
                     "type": "string"
                 },
+                "resolverRulesOwnerAccount": {
+                    "type": "string",
+                    "oneOf": [
+                        {
+                            "pattern": "^\\d{12}$"
+                        },
+                        {
+                            "const": ""
+                        }
+                    ]
+                },
                 "serviceCIDR": {
                     "type": "string"
                 },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -45,6 +45,9 @@ network:
   transitGatewayID: ""
   # prefixListID is the ID of the Managed Prefix List to use when `mode` is set to `UserManaged`.
   prefixListID: ""
+  # resolverRulesOwnerAccount is the AWS account that created the Resolver Rules that we want to associate with the WC VPC.
+  # When empty, no resolver rules will be associated with the WC VPC.
+  resolverRulesOwnerAccount: ""
 
   # subnets defines all the subnets for a cluster.
   subnets:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/25571

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
