### PR TITLE
Customize tags per individual subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Customize tags per individual subnet.
+
 ## [0.24.0] - 2023-02-02
 
 ### Breaking Change

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can have VPC Endpoints target specific subnets by using the `subnet.giantswa
     availabilityZone: c
   isPublic: true
   tags:
-    subnet.giantswarm.io/role: attatchments
+    subnet.giantswarm.io/role: attachments
     subnet.giantswarm.io/endpoints: "true"
 ```
 
@@ -129,7 +129,7 @@ You can have Transit Gateway Attachments target specific subnets by using the `s
     availabilityZone: c
   isPublic: true
   tags:
-    subnet.giantswarm.io/role: attatchments
+    subnet.giantswarm.io/role: attachments
     subnet.giantswarm.io/tgw-attachments: "true"
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ network:
     isPublic: true
     tags:
       subnet.giantswarm.io/role: bastion
+  # Ingress load balancer subnets
+  - cidrBlocks:
+    - cidr: 10.0.3.0/24
+      availabilityZone: a
+      tags:
+        Name: cluster-ingress-lb-a
+    - cidr: 10.0.4.0/24
+      availabilityZone: b
+      tags:
+        Name: cluster-ingress-lb-b
+    - cidr: 10.0.5.0/24
+      availabilityZone: c
+      tags:
+        Name: cluster-ingress-lb-c
+    isPublic: true
+    tags:
+      subnet.giantswarm.io/role: ingress
 ```
 
 The desired subnet can then be targetted by using the `subnetTags` value to set the AWS tags to match on. For example:

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -49,6 +49,9 @@ spec:
       isPublic: {{ $subnet.isPublic | default false }}
       tags:
         {{- toYaml $subnet.tags | nindent 8 }}
+        {{- if $cidr.tags }}
+        {{- toYaml $cidr.tags | nindent 8 }}
+        {{- end }}
     {{- end }}
     {{- end }}
   sshKeyName: ssh-key

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -170,6 +170,9 @@
                                         },
                                         "availabilityZone": {
                                             "type": "string"
+                                        },
+                                        "tags": {
+                                            "type": "object"
                                         }
                                     }
                                 }


### PR DESCRIPTION
### What this PR does / why we need it

Customize tags per individual subnet in order to set a different name for each ingress controller LB subnet.

Additional details in the [Slack thread](https://gigantic.slack.com/archives/C03LV8E0RL7/p1675755946020219).

Given the following `values.yaml` snippet:
```
network:
  availabilityZoneUsageLimit: 3
  vpcCIDR: 10.234.0.0/16
  vpcMode: private
  apiMode: private
  dnsMode: private
  topologyMode: GiantSwarmManaged
  subnets:
  # api-server subnets [HACK: must come first in the list]
  - cidrBlocks:
    - cidr: 10.234.0.0/24
      availabilityZone: a
    - cidr: 10.234.1.0/24
      availabilityZone: b
    - cidr: 10.234.2.0/24
      availabilityZone: c
    isPublic: false
    tags:
      subnet.giantswarm.io/role: api-server-elb

  # Control plane nodes subnets
  - cidrBlocks:
    - cidr: 10.234.4.0/22
      availabilityZone: a
    - cidr: 10.234.8.0/22
      availabilityZone: b
    - cidr: 10.234.12.0/22
      availabilityZone: c
    isPublic: false
    tags:
      subnet.giantswarm.io/role: control-plane

  # Bastion nodes subnets
  - cidrBlocks:
    - cidr: 10.234.16.0/24
      availabilityZone: a
    - cidr: 10.234.17.0/24
      availabilityZone: b
    - cidr: 10.234.18.0/24
      availabilityZone: c
    isPublic: true
    tags:
      subnet.giantswarm.io/role: bastion

  # vpc endpoints and (eventually) transit gateway 
  - cidrBlocks:
    - cidr: 10.234.19.0/24
      availabilityZone: a
    - cidr: 10.234.20.0/24
      availabilityZone: b
    - cidr: 10.234.21.0/24
      availabilityZone: c
    isPublic: true
    tags:
      subnet.giantswarm.io/role: attachments
      subnet.giantswarm.io/endpoints: "true"

  # Worker nodes subnets
  - cidrBlocks:
    - cidr: 10.234.22.0/24
      availabilityZone: a
    - cidr: 10.234.23.0/24
      availabilityZone: b
    - cidr: 10.234.24.0/24
      availabilityZone: c
    isPublic: false
    tags:
      subnet.giantswarm.io/role: workers

  # Ingress LB
  - cidrBlocks:
    - cidr: 10.234.26.0/24
      availabilityZone: a
      tags:
        Name: ingress-lb-a
    - cidr: 10.234.27.0/24
      availabilityZone: b
      tags:
        Name: ingress-lb-b
    - cidr: 10.234.28.0/24
      availabilityZone: c
      tags:
        Name: ingress-lb-c
    isPublic: false
    tags:
      subnet.giantswarm.io/role: ingress
```

the output is:
```
    subnets:
    - cidrBlock: "10.234.0.0/24"
      availabilityZone: "eu-north-1a"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: api-server-elb
    - cidrBlock: "10.234.1.0/24"
      availabilityZone: "eu-north-1b"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: api-server-elb
    - cidrBlock: "10.234.2.0/24"
      availabilityZone: "eu-north-1c"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: api-server-elb
    - cidrBlock: "10.234.4.0/22"
      availabilityZone: "eu-north-1a"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: control-plane
    - cidrBlock: "10.234.8.0/22"
      availabilityZone: "eu-north-1b"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: control-plane
    - cidrBlock: "10.234.12.0/22"
      availabilityZone: "eu-north-1c"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: control-plane
    - cidrBlock: "10.234.16.0/24"
      availabilityZone: "eu-north-1a"
      isPublic: true
      tags:
        subnet.giantswarm.io/role: bastion
    - cidrBlock: "10.234.17.0/24"
      availabilityZone: "eu-north-1b"
      isPublic: true
      tags:
        subnet.giantswarm.io/role: bastion
    - cidrBlock: "10.234.18.0/24"
      availabilityZone: "eu-north-1c"
      isPublic: true
      tags:
        subnet.giantswarm.io/role: bastion
    - cidrBlock: "10.234.19.0/24"
      availabilityZone: "eu-north-1a"
      isPublic: true
      tags:
        subnet.giantswarm.io/endpoints: "true"
        subnet.giantswarm.io/role: attachments
    - cidrBlock: "10.234.20.0/24"
      availabilityZone: "eu-north-1b"
      isPublic: true
      tags:
        subnet.giantswarm.io/endpoints: "true"
        subnet.giantswarm.io/role: attachments
    - cidrBlock: "10.234.21.0/24"
      availabilityZone: "eu-north-1c"
      isPublic: true
      tags:
        subnet.giantswarm.io/endpoints: "true"
        subnet.giantswarm.io/role: attachments
    - cidrBlock: "10.234.22.0/24"
      availabilityZone: "eu-north-1a"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: workers
    - cidrBlock: "10.234.23.0/24"
      availabilityZone: "eu-north-1b"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: workers
    - cidrBlock: "10.234.24.0/24"
      availabilityZone: "eu-north-1c"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: workers
    - cidrBlock: "10.234.26.0/24"
      availabilityZone: "eu-north-1a"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: ingress
        Name: ingress-lb-a
    - cidrBlock: "10.234.27.0/24"
      availabilityZone: "eu-north-1b"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: ingress
        Name: ingress-lb-b
    - cidrBlock: "10.234.28.0/24"
      availabilityZone: "eu-north-1c"
      isPublic: false
      tags:
        subnet.giantswarm.io/role: ingress
        Name: ingress-lb-c
```


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
