### PR TITLE
Fail in Helm template if `dnsMode=public` is combined with a `baseDomain` ending with `.internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fail in Helm template if `dnsMode=public` is combined with a `baseDomain` ending with `.internal`
+
 ## [0.21.0] - 2023-01-19
 
 ### Breaking Change

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -1,4 +1,7 @@
 {{- define "aws-cluster" }}
+{{- if and (regexMatch "\\.internal$" (required "baseDomain is required" .Values.baseDomain)) (eq (required "network.dnsMode required" .Values.network.dnsMode) "public") }}
+{{- fail "dnsMode=public cannot be combined with a '*.internal' baseDomain since reserved-as-private TLDs are not propagated to public DNS servers and therefore crucial DNS records such as api.<baseDomain> cannot be looked up" }}
+{{- end }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -185,7 +185,8 @@
                     "type": "string"
                 },
                 "dnsMode": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["public", "private"]
                 },
                 "podCIDR": {
                     "type": "string"


### PR DESCRIPTION
### What this PR does / why we need it

[Related chat](https://gigantic.slack.com/archives/C04AJ5FJHEK/p1676463597260979)

I tested on an MC with base domain `gaws.gigantic.internal`, but had set `dnsMode` to `public`. Since `.internal` and other TLDs are reserved for private use, such records will not propagate to public DNS servers. In my case, the workload cluster then failed to come up because Cilium could not look up `api.<baseDomain>` via DNS. With this change, we throw an error early instead of allowing this human mistake.

```
λ helm template helm/cluster-aws/ --set organization=bam --set baseDomain=gaws.bla.internal --set network.dnsMode=private
---
# Source: cluster-aws/templates/list.yaml
apiVersion: v1
[...]

# Bad
λ helm template helm/cluster-aws/ --set organization=bam --set baseDomain=gaws.bla.internal --set network.dnsMode=public
Error: execution error at (cluster-aws/templates/list.yaml:7:4): dnsMode=public cannot be combined with a '*.internal' baseDomain since reserved-as-private TLDs are not propagated to public DNS servers and therefore crucial DNS records such as api.<baseDomain> cannot be looked up
```

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
