### PR TITLE
Quote subnet tag filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Breaking Change
+### Breaking Change
 
 - Replaced `registry` parameter  to `connectivity.containerRegistries` in the values schema
+
+### Fixed
+
+- Quote subnet tag filters in order to avoid type conversion errors.
 
 ### Added
 
 - Made registry configurations `connectivity.containerRegistries` dynamic to accept as many container registries and mirrors as needed
-
-### Added
-
 - Expose helm value for customers to decide whether or not VPC endpoint should be created by Giantswarm.
 
 ### Changed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -40,7 +40,7 @@ template:
         {{- range $i, $tags :=  .Values.controlPlane.subnetTags }}
         - name: tag:{{ keys $tags | first }}
           values:
-          - {{ index $tags (keys $tags | first) }}
+          - {{ index $tags (keys $tags | first) | quote }}
         {{- end }}
 {{- end }}
 

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -46,7 +46,7 @@ spec:
     {{- range $i, $tags := .subnetTags }}
     - name: tag:{{ keys $tags | first }}
       values:
-      - {{ index $tags (keys $tags | first) }}
+      - {{ index $tags (keys $tags | first) | quote }}
     {{- end }}
   awsLaunchTemplate:
     {{- include "ami" $ | nindent 4 }}


### PR DESCRIPTION
### What this PR does / why we need it

Quote subnet tag filters in order to avoid type conversion errors.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
