### PR TITLE
add-machine-health-check (#223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MachineHealthCheck` for all nodes.
+
 ### Changed
 
 - Fail in Helm template if `dnsMode=public` is combined with a `baseDomain` ending with `.internal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `MachineHealthCheck` for all nodes.
+- Add `MachineHealthCheck` for control plane nodes.
 
 ### Changed
 

--- a/helm/cluster-aws/templates/_machine_health_check.tpl
+++ b/helm/cluster-aws/templates/_machine_health_check.tpl
@@ -5,7 +5,7 @@ kind: MachineHealthCheck
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}
+  name: {{ include "resource.default.name" . }}-control-plane
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterName: {{ include "resource.default.name" $ }}
@@ -14,6 +14,7 @@ spec:
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
+      cluster.x-k8s.io/control-plane: ""
   unhealthyConditions:
   - type: Ready
     status: Unknown

--- a/helm/cluster-aws/templates/_machine_health_check.tpl
+++ b/helm/cluster-aws/templates/_machine_health_check.tpl
@@ -1,0 +1,25 @@
+{{- define "machine-health-check" }}
+{{- if .Values.machineHealthCheck.enabled }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ include "resource.default.name" . }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterName: {{ include "resource.default.name" $ }}
+  maxUnhealthy: {{ .Values.machineHealthCheck.maxUnhealthy }}
+  nodeStartupTimeout: {{ .Values.machineHealthCheck.nodeStartupTimeout }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
+  unhealthyConditions:
+  - type: Ready
+    status: Unknown
+    timeout: {{ .Values.machineHealthCheck.unhealthyUnknownTimeout }}
+  - type: Ready
+    status: "False"
+    timeout: {{ .Values.machineHealthCheck.unhealthyNotReadyTimeout }}
+{{- end -}}
+{{- end -}}

--- a/helm/cluster-aws/templates/_machine_health_check.tpl
+++ b/helm/cluster-aws/templates/_machine_health_check.tpl
@@ -1,5 +1,5 @@
 {{- define "machine-health-check" }}
-{{- if .Values.machineHealthCheck.enabled }}
+{{- if .Values.controlPlane.machineHealthCheck.enabled }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
@@ -9,8 +9,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterName: {{ include "resource.default.name" $ }}
-  maxUnhealthy: {{ .Values.machineHealthCheck.maxUnhealthy }}
-  nodeStartupTimeout: {{ .Values.machineHealthCheck.nodeStartupTimeout }}
+  maxUnhealthy: {{ .Values.controlPlane.machineHealthCheck.maxUnhealthy }}
+  nodeStartupTimeout: {{ .Values.controlPlane.machineHealthCheck.nodeStartupTimeout }}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
@@ -18,9 +18,9 @@ spec:
   unhealthyConditions:
   - type: Ready
     status: Unknown
-    timeout: {{ .Values.machineHealthCheck.unhealthyUnknownTimeout }}
+    timeout: {{ .Values.controlPlane.machineHealthCheck.unhealthyUnknownTimeout }}
   - type: Ready
     status: "False"
-    timeout: {{ .Values.machineHealthCheck.unhealthyNotReadyTimeout }}
+    timeout: {{ .Values.controlPlane.machineHealthCheck.unhealthyNotReadyTimeout }}
 {{- end -}}
 {{- end -}}

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -15,3 +15,5 @@
 ---
 {{ end }}
 {{- include "machine-pools" . }}
+---
+{{- include "machine-health-check" . }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -75,6 +75,26 @@
                 "kubeletVolumeSizeGB": {
                     "type": "integer"
                 },
+		"machineHealthCheck": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxUnhealthy": {
+                            "type": "string"
+                        },
+                        "nodeStartupTimeout": {
+                            "type": "string"
+                        },
+                        "unhealthyNotReadyTimeout": {
+                            "type": "string"
+                        },
+                        "unhealthyUnknownTimeout": {
+                            "type": "string"
+                        }
+                    }
+       		},
                 "rootVolumeSizeGB": {
                     "type": "integer"
                 },
@@ -112,26 +132,6 @@
         "kubernetesVersion": {
             "type": "string"
         },
-	"machineHealthCheck": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "maxUnhealthy": {
-                    "type": "string"
-                },
-                "nodeStartupTimeout": {
-                    "type": "string"
-                },
-                "unhealthyNotReadyTimeout": {
-                    "type": "string"
-                },
-                "unhealthyUnknownTimeout": {
-                    "type": "string"
-                 }
-             }
-         },
         "machinePools": {
             "type": "object",
             "patternProperties": {

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -112,6 +112,26 @@
         "kubernetesVersion": {
             "type": "string"
         },
+	"machineHealthCheck": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxUnhealthy": {
+                    "type": "string"
+                },
+                "nodeStartupTimeout": {
+                    "type": "string"
+                },
+                "unhealthyNotReadyTimeout": {
+                    "type": "string"
+                },
+                "unhealthyUnknownTimeout": {
+                    "type": "string"
+                 }
+             }
+         },
         "machinePools": {
             "type": "object",
             "patternProperties": {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -127,7 +127,7 @@ ami: ""
 machineHealthCheck:
   enabled: true
   maxUnhealthy: "40%"
-  nodeStartupTimeout: "20m0s"
+  nodeStartupTimeout: "8m0s"
   unhealthyUnknownTimeout: "10m0s"
   unhealthyNotReadyTimeout: "10m0s"
 

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -123,6 +123,7 @@ flatcarAWSAccount: "075585003325"
 ami: ""
 
 # machine health check settings
+# for control plane nodes only as the check do not support MachinePools yet
 machineHealthCheck:
   enabled: true
   maxUnhealthy: "40%"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -96,8 +96,16 @@ controlPlane:
   etcdVolumeSizeGB: 100
   containerdVolumeSizeGB: 100
   kubeletVolumeSizeGB: 100
+  # machine health check settings
+  machineHealthCheck:
+    enabled: true
+    maxUnhealthy: "40%"
+    nodeStartupTimeout: "8m0s"
+    unhealthyUnknownTimeout: "10m0s"
+    unhealthyNotReadyTimeout: "10m0s"
   # subnetTags:
   # - subnet.giantswarm.io/role: control-plane
+
 
 # For structure of the machine pool object see defaultMachinePools
 machinePools: {}
@@ -121,15 +129,6 @@ flatcarAWSAccount: "075585003325"
 
 # Used to override the AMI lookup and instead use a specific image
 ami: ""
-
-# machine health check settings
-# for control plane nodes only as the check do not support MachinePools yet
-machineHealthCheck:
-  enabled: true
-  maxUnhealthy: "40%"
-  nodeStartupTimeout: "8m0s"
-  unhealthyUnknownTimeout: "10m0s"
-  unhealthyNotReadyTimeout: "10m0s"
 
 oidc:
   issuerUrl: ""

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -122,6 +122,14 @@ flatcarAWSAccount: "075585003325"
 # Used to override the AMI lookup and instead use a specific image
 ami: ""
 
+# machine health check settings
+machineHealthCheck:
+  enabled: true
+  maxUnhealthy: "40%"
+  nodeStartupTimeout: "20m0s"
+  unhealthyUnknownTimeout: "10m0s"
+  unhealthyNotReadyTimeout: "10m0s"
+
 oidc:
   issuerUrl: ""
   caPem: ""


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1978


probably should be disabled on mc-bootstrap as durign the as they do not recommend to use it during `cluster move`