### PR TITLE
Add property schema for subnet tags objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Values schema:
   - Added annotations
   - Applied normalization using `schemalint normalize`
+  - Added property schema for subnetTags objects
 
 ## [0.27.0] - 2023-03-01
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -1,5 +1,13 @@
 {
     "$defs": {
+        "awsResourceTagValue": {
+            "$comment": "Restrictions based on https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions",
+            "maxLength": 256,
+            "minLength": 0,
+            "pattern": "^[ a-zA-Z0-9\\._:/=+-@]+$",
+            "title": "Tag value",
+            "type": "string"
+        },
         "machinePool": {
             "properties": {
                 "availabilityZones": {
@@ -68,6 +76,9 @@
                 "subnetTags": {
                     "description": "Tags to filter which AWS subnets will be used for this node pool.",
                     "items": {
+                        "additionalProperties": {
+                            "$ref": "#/$defs/awsResourceTagValue"
+                        },
                         "title": "Subnet tag",
                         "type": "object"
                     },
@@ -129,6 +140,9 @@
                 "subnetTags": {
                     "description": "Tags to filter which AWS subnets will be used for the bastion hosts.",
                     "items": {
+                        "additionalProperties": {
+                            "$ref": "#/$defs/awsResourceTagValue"
+                        },
                         "title": "Subnet tag",
                         "type": "object"
                     },
@@ -226,6 +240,9 @@
                 "subnetTags": {
                     "description": "Tags to select AWS resources for the control plane by.",
                     "items": {
+                        "additionalProperties": {
+                            "$ref": "#/$defs/awsResourceTagValue"
+                        },
                         "title": "Subnet tag",
                         "type": "object"
                     },
@@ -370,6 +387,9 @@
                                             "type": "string"
                                         },
                                         "tags": {
+                                            "additionalProperties": {
+                                                "$ref": "#/$defs/awsResourceTagValue"
+                                            },
                                             "description": "AWS resource tags to assign to this subnet.",
                                             "title": "Tags",
                                             "type": "object"
@@ -385,6 +405,9 @@
                                 "type": "boolean"
                             },
                             "tags": {
+                                "additionalProperties": {
+                                    "$ref": "#/$defs/awsResourceTagValue"
+                                },
                                 "description": "AWS resource tags to assign to this CIDR block.",
                                 "title": "Tags",
                                 "type": "object"


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2127

The goal of this PR is to add missing schema for objects related to AWS resource tags.

My understanding is that the goal of these objects is to allow entry of user-defined key-value-pairs. This can be achieved using `additionalProperties` or `patternProperties`.

I'm deciding for `additionalProperties` here for now, which leaves greatest possible freedom on the format of the key. The `patternProperties` method instead would allow to impose certain regex restrictions on the key format, like e. g. disallow whitespace.

The validation pattern for values encodes what's written in https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
