### PR TITLE
Add schema for /connectivity/containerRegistries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Values schema:
   - Added annotations
   - Applied normalization using `schemalint normalize`
+  - Added property schema for /connectivity/containerRegistries
 
 ## [0.27.0] - 2023-03-01
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -152,6 +152,52 @@
         "connectivity": {
             "properties": {
                 "containerRegistries": {
+                    "additionalProperties": {
+                        "description": "Container registries and mirrors",
+                        "items": {
+                            "properties": {
+                                "credentials": {
+                                    "properties": {
+                                        "auth": {
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password.",
+                                            "title": "Auth",
+                                            "type": "string"
+                                        },
+                                        "identitytoken": {
+                                            "description": "Used to authenticate the user and obtain an access token for the registry.",
+                                            "title": "Identity token",
+                                            "type": "string"
+                                        },
+                                        "password": {
+                                            "description": "Used to authenticate for the registry with username/password.",
+                                            "title": "Password",
+                                            "type": "string"
+                                        },
+                                        "username": {
+                                            "description": "Used to authenticate for the registry with username/password.",
+                                            "title": "Username",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Credentials",
+                                    "type": "object"
+                                },
+                                "endpoint": {
+                                    "description": "Endpoint for the container registry.",
+                                    "title": "Endpoint",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "endpoint"
+                            ],
+                            "title": "Registry",
+                            "type": "object"
+                        },
+                        "title": "Registries",
+                        "type": "array"
+                    },
+                    "description": "Endpoints and credentials configuration for container registries.",
                     "title": "Container registries",
                     "type": "object"
                 }


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2127

The goal of this PR is to add the missing property schema for `/connectivity/containerRegistries`.

The schema was already available in cluster-cloud-director and example values were found in `values.yaml`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
