### PR TITLE
Move defaults to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Applied normalization using `schemalint normalize`
   - Added property schema for /connectivity/containerRegistries
   - Added property schema for subnetTags objects
+  - Added default values
 
 ## [0.27.0] - 2023-03-01
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -117,7 +117,8 @@
                 },
                 "region": {
                     "title": "Region",
-                    "type": "string"
+                    "type": "string",
+                    "default": ""
                 }
             },
             "title": "AWS settings",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -100,13 +100,15 @@
         "aws": {
             "properties": {
                 "awsClusterRole": {
-                    "$comment": "Please use 'awsClusterRoleIdentityName'.",
+                    "$comment": "Please use awsClusterRoleIdentityName.",
                     "deprecated": true,
                     "title": "Cluster role",
                     "type": "string"
                 },
                 "awsClusterRoleIdentityName": {
+                    "$comment": "See also https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html#awsclusterroleidentity",
                     "default": "default",
+                    "description": "Name of an AWSClusterRoleIdentity object. This in turn refers to the IAM role used to create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create all resources in that account. Note: This name does not refer directly to an IAM role name/ARN.",
                     "maxLength": 63,
                     "minLength": 1,
                     "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -100,11 +100,13 @@
         "aws": {
             "properties": {
                 "awsClusterRole": {
+                    "$comment": "Please use 'awsClusterRoleIdentityName'.",
                     "deprecated": true,
                     "title": "Cluster role",
                     "type": "string"
                 },
                 "awsClusterRoleIdentityName": {
+                    "default": "default",
                     "maxLength": 63,
                     "minLength": 1,
                     "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$",
@@ -126,14 +128,17 @@
         "bastion": {
             "properties": {
                 "enabled": {
+                    "default": true,
                     "title": "Enable",
                     "type": "boolean"
                 },
                 "instanceType": {
+                    "default": "t3.small",
                     "title": "EC2 instance type",
                     "type": "string"
                 },
                 "replicas": {
+                    "default": 1,
                     "title": "Number of hosts",
                     "type": "integer"
                 },
@@ -222,28 +227,34 @@
         "controlPlane": {
             "properties": {
                 "containerdVolumeSizeGB": {
+                    "default": 100,
                     "title": "Containerd volume size (GB)",
                     "type": "integer"
                 },
                 "etcdVolumeSizeGB": {
+                    "default": 100,
                     "title": "Etcd volume size (GB)",
                     "type": "integer"
                 },
                 "instanceType": {
+                    "default": "m5.xlarge",
                     "title": "EC2 instance type",
                     "type": "string"
                 },
                 "kubeletVolumeSizeGB": {
+                    "default": 100,
                     "title": "Kubelet volume size (GB)",
                     "type": "integer"
                 },
                 "machineHealthCheck": {
                     "properties": {
                         "enabled": {
+                            "default": true,
                             "title": "Enable",
                             "type": "boolean"
                         },
                         "maxUnhealthy": {
+                            "default": "40%",
                             "examples": [
                                 "40%"
                             ],
@@ -251,6 +262,7 @@
                             "type": "string"
                         },
                         "nodeStartupTimeout": {
+                            "default": "8m0s",
                             "description": "Determines how long a machine health check should wait for a node to join the cluster, before considering a machine unhealthy.",
                             "examples": [
                                 "10m",
@@ -260,6 +272,7 @@
                             "type": "string"
                         },
                         "unhealthyNotReadyTimeout": {
+                            "default": "10m0s",
                             "description": "If a node is not in condition 'Ready' after this timeout, it will be considered unhealthy.",
                             "examples": [
                                 "300s"
@@ -268,6 +281,7 @@
                             "type": "string"
                         },
                         "unhealthyUnknownTimeout": {
+                            "default": "10m0s",
                             "description": "If a node is in 'Unknown' condition after this timeout, it will be considered unhealthy.",
                             "examples": [
                                 "300s"
@@ -280,6 +294,7 @@
                     "type": "object"
                 },
                 "rootVolumeSizeGB": {
+                    "default": 120,
                     "title": "Root volume size (GB)",
                     "type": "integer"
                 },
@@ -300,6 +315,15 @@
             "type": "object"
         },
         "defaultMachinePools": {
+            "default": {
+                "def00": {
+                    "customNodeLabels": [
+                        "label=default"
+                    ],
+                    "instanceType": "m5.xlarge",
+                    "minSize": 3
+                }
+            },
             "patternProperties": {
                 "^[a-z0-9]{5,10}$": {
                     "$ref": "#/$defs/machinePool"
@@ -309,6 +333,7 @@
             "type": "object"
         },
         "flatcarAWSAccount": {
+            "default": "075585003325",
             "description": "AWS account ID owning the Flatcar Container Linux AMI.",
             "title": "AWS account owning Flatcar image",
             "type": "string"
@@ -319,20 +344,24 @@
             "type": "string"
         },
         "includeClusterResourceSet": {
+            "default": true,
             "title": "Include ClusterResourceSet",
             "type": "boolean"
         },
         "kubectlImage": {
             "properties": {
                 "name": {
+                    "default": "giantswarm/kubectl",
                     "title": "Repository",
                     "type": "string"
                 },
                 "registry": {
+                    "default": "quay.io",
                     "title": "Registry",
                     "type": "string"
                 },
                 "tag": {
+                    "default": "1.23.5",
                     "title": "Tag",
                     "type": "string"
                 }
@@ -341,6 +370,7 @@
             "type": "object"
         },
         "kubernetesVersion": {
+            "default": "1.23.16",
             "examples": [
                 "1.24.7"
             ],
@@ -359,11 +389,17 @@
         "network": {
             "properties": {
                 "apiMode": {
+                    "default": "public",
                     "description": "Whether the Kubernetes API server load balancer should be reachable from the internet (public) or internal only (private).",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
                     "title": "API mode",
                     "type": "string"
                 },
                 "availabilityZoneUsageLimit": {
+                    "default": 3,
                     "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
                     "title": "Availability zones",
                     "type": "integer"
@@ -378,6 +414,7 @@
                     "type": "string"
                 },
                 "dnsMode": {
+                    "default": "public",
                     "description": "Whether the Route53 hosted zone of this cluster should be public or private.",
                     "enum": [
                         "public",
@@ -387,6 +424,7 @@
                     "type": "string"
                 },
                 "podCIDR": {
+                    "default": "100.64.0.0/12",
                     "description": "IPv4 address range for pods, in CIDR notation.",
                     "title": "Pod subnet",
                     "type": "string"
@@ -410,11 +448,48 @@
                     "type": "string"
                 },
                 "serviceCIDR": {
+                    "default": "172.31.0.0/16",
                     "description": "IPv4 address range for services, in CIDR notation.",
                     "title": "Service subnet",
                     "type": "string"
                 },
                 "subnets": {
+                    "default": [
+                        {
+                            "cidrBlocks": [
+                                {
+                                    "availabilityZone": "a",
+                                    "cidr": "10.0.0.0/20"
+                                },
+                                {
+                                    "availabilityZone": "b",
+                                    "cidr": "10.0.16.0/20"
+                                },
+                                {
+                                    "availabilityZone": "c",
+                                    "cidr": "10.0.32.0/20"
+                                }
+                            ],
+                            "isPublic": true
+                        },
+                        {
+                            "cidrBlocks": [
+                                {
+                                    "availabilityZone": "a",
+                                    "cidr": "10.0.64.0/18"
+                                },
+                                {
+                                    "availabilityZone": "b",
+                                    "cidr": "10.0.128.0/18"
+                                },
+                                {
+                                    "availabilityZone": "c",
+                                    "cidr": "10.0.192.0/18"
+                                }
+                            ],
+                            "isPublic": false
+                        }
+                    ],
                     "items": {
                         "properties": {
                             "cidrBlocks": {
@@ -466,7 +541,13 @@
                     "type": "array"
                 },
                 "topologyMode": {
+                    "default": "None",
                     "description": "Defines the type of cross-cluster networking architecture between management and workload cluster. Valid values: GiantSwarmManaged, UserManaged, None.",
+                    "enum": [
+                        "None",
+                        "GiantSwarmManaged",
+                        "UserManaged"
+                    ],
                     "title": "Topology mode",
                     "type": "string"
                 },
@@ -476,17 +557,28 @@
                     "type": "string"
                 },
                 "vpcCIDR": {
+                    "default": "10.0.0.0/16",
                     "description": "IPv4 address range to assign to this cluster's VPC, in CIDR notation.",
                     "title": "VPC subnet",
                     "type": "string"
                 },
                 "vpcEndpointMode": {
+                    "default": "GiantSwarmManaged",
                     "description": "Who is reponsible for creation and management of VPC endpoints.",
+                    "enum": [
+                        "GiantSwarmManaged",
+                        "UserManaged"
+                    ],
                     "title": "VPC endpoint mode",
                     "type": "string"
                 },
                 "vpcMode": {
+                    "default": "public",
                     "description": "Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
                     "title": "VPC mode",
                     "type": "string"
                 }
@@ -553,6 +645,7 @@
             "type": "object"
         },
         "sshSSOPublicKey": {
+            "default": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io",
             "title": "SSH public key for single sign-on",
             "type": "string"
         }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,166 +1,62 @@
-clusterName: ""  # Cluster name. Defaults to chart release name
-clusterDescription: "test"  # Cluster description used in metadata.
-organization: ""  # Organization in which to create the cluster.
-kubernetesVersion: 1.23.16
-baseDomain: ""  # Customer base domain, generally of the form "<customer codename>.gigantic.io".
-
 aws:
-  region: ""
-  # awsClusterRoleIdentityName is the name of an `AWSClusterRoleIdentity` object. This in turn refers to the IAM role used to
-  # create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create
-  # all resources in that account. The value of `awsClusterRoleIdentityName` does not refer directly to an IAM role name/ARN!
-  # See also https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html#awsclusterroleidentity.
-  awsClusterRoleIdentityName: "default"
-  awsClusterRole: ""  # deprecated, please use `awsClusterRoleIdentityName`
-
-network:
-  availabilityZoneUsageLimit: 3  # amount of AZ that should be used for the machines
-  vpcCIDR: 10.0.0.0/16  # cidr range for the VPC
-  serviceCIDR: 172.31.0.0/16
-  podCIDR: 100.64.0.0/12
-
-  # vpcMode defines if the VPC is created with public, internet facing resources (public subnets, NAT gateway) or not
-  # Valid value: public, private
-  vpcMode: public
-
-  # apiMode defines if the Kubernetes API server load balancer should be public (internet facing) or private (internal only)
-  # Valid value: public, private
-  apiMode: public
-
-  # dnsMode defines if the Route53 Hosted Zone should be public or private
-  # Valid value: public, private
-  dnsMode: public
-
-  # vpcEndpointMode defines if VPC endpoints should be created by GiantSwarm or not
-  # Valid value: UserManaged, GiantSwarmManaged
-  vpcEndpointMode: GiantSwarmManaged
-
-  # dnsAssignAdditionalVPCs - when dnsMode is 'private', listed vpc will be assigned to the private hosted zone
-  # value should be vpc id separated by comma
-  # ie: "vpc-x2aeasd1d,vpc-98injA"
-  dnsAssignAdditionalVPCs: ""
-
-
-  # topologyMode defines the type of cross-cluster networking architecture between MCs and WCs
-  # Valid values: GiantSwarmManaged, UserManaged, None
-  topologyMode: None
-  # transitGatewayID is the ID of the TGW to use when `mode` is set to `UserManaged`.
-  transitGatewayID: ""
-  # prefixListID is the ID of the Managed Prefix List to use when `mode` is set to `UserManaged`.
-  prefixListID: ""
-  # resolverRulesOwnerAccount is the AWS account that created the Resolver Rules that we want to associate with the WC VPC.
-  # When empty, no resolver rules will be associated with the WC VPC.
-  resolverRulesOwnerAccount: ""
-
-  # subnets defines all the subnets for a cluster.
-  subnets:
-  # The CAPA default subnet layout
-  - cidrBlocks:
-    - cidr: 10.0.0.0/20
-      availabilityZone: a
-    - cidr: 10.0.16.0/20
-      availabilityZone: b
-    - cidr: 10.0.32.0/20
-      availabilityZone: c
-    isPublic: true
-  - cidrBlocks:
-    - cidr: 10.0.64.0/18
-      availabilityZone: a
-    - cidr: 10.0.128.0/18
-      availabilityZone: b
-    - cidr: 10.0.192.0/18
-      availabilityZone: c
-    isPublic: false
-
-  # # Our previous default for private clusters
-  # - cidrBlocks:
-  #   - cidr: 10.0.0.0/18
-  #     availabilityZone: a
-  #   - cidr: 10.0.64.0/18
-  #     availabilityZone: b
-  #   - cidr: 10.0.128.0/18
-  #     availabilityZone: c
-  #   isPublic: false
-
+  awsClusterRoleIdentityName: default
 bastion:
   enabled: true
   instanceType: t3.small
   replicas: 1
-  # subnetTags:
-  # - subnet.giantswarm.io/role: bastion
-
+connectivity: {}
 controlPlane:
-  instanceType: m5.xlarge
-  rootVolumeSizeGB: 120
-  etcdVolumeSizeGB: 100
   containerdVolumeSizeGB: 100
+  etcdVolumeSizeGB: 100
+  instanceType: m5.xlarge
   kubeletVolumeSizeGB: 100
-  # machine health check settings
   machineHealthCheck:
     enabled: true
-    maxUnhealthy: "40%"
-    nodeStartupTimeout: "8m0s"
-    unhealthyUnknownTimeout: "10m0s"
-    unhealthyNotReadyTimeout: "10m0s"
-  # subnetTags:
-  # - subnet.giantswarm.io/role: control-plane
-
-
-# For structure of the machine pool object see defaultMachinePools
-machinePools: {}
-
-defaultMachinePools:  # Machine pools used if none is specified by user
-  def00:  # Name of node pool.
-    availabilityZones: []
-    instanceType: m5.xlarge
-    minSize: 3  # Number of replicas in node pool. maxSize: 3 rootVolumeSizeGB: 300
+    maxUnhealthy: 40%
+    nodeStartupTimeout: 8m0s
+    unhealthyNotReadyTimeout: 10m0s
+    unhealthyUnknownTimeout: 10m0s
+  rootVolumeSizeGB: 120
+defaultMachinePools:
+  def00:
     customNodeLabels:
-    - label=default
-    customNodeTaints: []
-    # - key: ""
-    #   value: ""
-    #   effect: "" # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-    # subnetTags:
-    # - subnet.giantswarm.io/role: workers
-
-sshSSOPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+      - label=default
+    instanceType: m5.xlarge
+    minSize: 3
 flatcarAWSAccount: "075585003325"
-
-# Used to override the AMI lookup and instead use a specific image
-ami: ""
-
-oidc:
-  issuerUrl: ""
-  caPem: ""
-  clientId: ""
-  usernameClaim: ""
-  groupsClaim: ""
-
-proxy:
-  enabled: false
-  http_proxy: ""
-  https_proxy: ""
-  no_proxy: ""
-
-# Used by `cluster-shared` library chart
 includeClusterResourceSet: true
 kubectlImage:
-  registry: quay.io
   name: giantswarm/kubectl
+  registry: quay.io
   tag: 1.23.5
-
-# Used to force-recreate resources that use a hash suffix in their name.
-# To use, set this to a random string to trigger new hash values to be generated.
-hashSalt: ""
-
-connectivity:
-  containerRegistries: {}
-#   docker.io:
-#   - endpoint: "registry-1.docker.io"
-#     credentials:
-#       username: ""
-#       password: ""
-#   - endpoint: "my-mirror-registry.mydomain.io"
-#     credentials:
-#       auth: ""
-#       identitytoken: ""
+kubernetesVersion: 1.23.16
+network:
+  apiMode: public
+  availabilityZoneUsageLimit: 3
+  dnsMode: public
+  podCIDR: 100.64.0.0/12
+  serviceCIDR: 172.31.0.0/16
+  subnets:
+    - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.0.0.0/20
+        - availabilityZone: b
+          cidr: 10.0.16.0/20
+        - availabilityZone: c
+          cidr: 10.0.32.0/20
+      isPublic: true
+    - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.0.64.0/18
+        - availabilityZone: b
+          cidr: 10.0.128.0/18
+        - availabilityZone: c
+          cidr: 10.0.192.0/18
+      isPublic: false
+  topologyMode: None
+  vpcCIDR: 10.0.0.0/16
+  vpcEndpointMode: GiantSwarmManaged
+  vpcMode: public
+oidc: {}
+proxy: {}
+sshSSOPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,5 +1,6 @@
 aws:
   awsClusterRoleIdentityName: default
+  region: ""
 bastion:
   enabled: true
   instanceType: t3.small


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2139

This PR moves the app default values "source of truth" to `values.schema.json`.

The `values.yaml` file still exists, but it gets generated via `helm-values-gen`.

Caution: Assuming that empty strings are not needed as default values, I skipped those (with the exception of /aws/region, where the missing value caused an error in the chart.)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
