### PR TITLE
Move /oidc to /controlPlane/oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added property schema for /connectivity/containerRegistries
   - Added property schema for subnetTags objects
   - Added default values
+  - Move /oidc to /controlPlane/oidc
 
 ## [0.27.0] - 2023-03-01
 

--- a/helm/cluster-aws/files/etc/ssl/certs/oidc.pem
+++ b/helm/cluster-aws/files/etc/ssl/certs/oidc.pem
@@ -1,3 +1,3 @@
-{{- if ne .Values.oidc.caPem "" -}}
-{{ .Values.oidc.caPem }}
+{{- if ne .Values.controlPlane.oidc.caPem "" -}}
+{{ .Values.controlPlane.oidc.caPem }}
 {{- end -}}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -74,8 +74,8 @@ spec:
         extraArgs:
           cloud-provider: aws
           service-account-issuer: PLACEHOLDER_CLOUDFRONT_DOMAIN
-          {{- if .Values.oidc.issuerUrl }}
-          {{- with .Values.oidc }}
+          {{- if .Values.controlPlane.oidc.issuerUrl }}
+          {{- with .Values.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -47,7 +47,7 @@ room for such suffix.
 {{- end -}}
 
 {{- define "oidcFiles" -}}
-{{- if ne .Values.oidc.caPem "" }}
+{{- if ne .Values.controlPlane.oidc.caPem "" }}
 - path: /etc/ssl/certs/oidc.pem
   permissions: "0600"
   encoding: base64

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -296,6 +296,34 @@
                     "title": "Machine health check",
                     "type": "object"
                 },
+                "oidc": {
+                    "properties": {
+                        "caPem": {
+                            "description": "Identity provider's CA certificate in PEM format.",
+                            "title": "Certificate authority",
+                            "type": "string"
+                        },
+                        "clientId": {
+                            "title": "Client ID",
+                            "type": "string"
+                        },
+                        "groupsClaim": {
+                            "title": "Groups claim",
+                            "type": "string"
+                        },
+                        "issuerUrl": {
+                            "description": "Exact issuer URL that will be included in identity tokens.",
+                            "title": "Issuer URL",
+                            "type": "string"
+                        },
+                        "usernameClaim": {
+                            "title": "Username claim",
+                            "type": "string"
+                        }
+                    },
+                    "title": "OIDC authentication",
+                    "type": "object"
+                },
                 "rootVolumeSizeGB": {
                     "default": 120,
                     "title": "Root volume size (GB)",
@@ -587,34 +615,6 @@
                 }
             },
             "title": "Network",
-            "type": "object"
-        },
-        "oidc": {
-            "properties": {
-                "caPem": {
-                    "description": "Identity provider's CA certificate in PEM format.",
-                    "title": "Certificate authority",
-                    "type": "string"
-                },
-                "clientId": {
-                    "title": "Client ID",
-                    "type": "string"
-                },
-                "groupsClaim": {
-                    "title": "Groups claim",
-                    "type": "string"
-                },
-                "issuerUrl": {
-                    "description": "Exact issuer URL that will be included in identity tokens.",
-                    "title": "Issuer URL",
-                    "type": "string"
-                },
-                "usernameClaim": {
-                    "title": "Username claim",
-                    "type": "string"
-                }
-            },
-            "title": "OIDC authentication",
             "type": "object"
         },
         "organization": {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -17,6 +17,7 @@ controlPlane:
     nodeStartupTimeout: 8m0s
     unhealthyNotReadyTimeout: 10m0s
     unhealthyUnknownTimeout: 10m0s
+  oidc: {}
   rootVolumeSizeGB: 120
 defaultMachinePools:
   def00:
@@ -58,6 +59,5 @@ network:
   vpcCIDR: 10.0.0.0/16
   vpcEndpointMode: GiantSwarmManaged
   vpcMode: public
-oidc: {}
 proxy: {}
 sshSSOPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This moves the /oidc object into /controlPlane.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
