### PR TITLE
Move /proxy to /connectivity/proxy and adapt property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /clusterDescription to /medatada/description
   - Move /organization to /metadata/organization
   - Move /oidc to /controlPlane/oidc
+  - Move /proxy to /connectivity/proxy
+    - Rename /proxy/no_proxy to /connectivity/proxy/noProxy
+    - Rename /proxy/http_proxy to /connectivity/proxy/httpProxy
+    - Rename /proxy/https_proxy to /connectivity/proxy/httpsProxy
 
 ### Fixed
 

--- a/helm/cluster-aws/files/http-proxy.conf
+++ b/helm/cluster-aws/files/http-proxy.conf
@@ -1,7 +1,7 @@
 [Service]
-Environment="HTTP_PROXY={{ .Values.proxy.http_proxy }}"
-Environment="HTTPS_PROXY={{ .Values.proxy.https_proxy }}"
-Environment="NO_PROXY=elb.amazonaws.com,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ $.Values.proxy.no_proxy }}"
-Environment="http_proxy={{ .Values.proxy.http_proxy }}"
-Environment="https_proxy={{ .Values.proxy.https_proxy }}"
-Environment="no_proxy=elb.amazonaws.com,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ $.Values.proxy.no_proxy }}"
+Environment="HTTP_PROXY={{ .Values.connectivity.proxy.httpProxy }}"
+Environment="HTTPS_PROXY={{ .Values.connectivity.proxy.httpsProxy }}"
+Environment="NO_PROXY=elb.amazonaws.com,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ $.Values.connectivity.proxy.noProxy }}"
+Environment="http_proxy={{ .Values.connectivity.proxy.httpProxy }}"
+Environment="https_proxy={{ .Values.connectivity.proxy.httpsProxy }}"
+Environment="no_proxy=elb.amazonaws.com,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ $.Values.connectivity.proxy.noProxy }}"

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -140,7 +140,7 @@ spec:
     {{- include "diskFiles" . | nindent 4 }}
     {{- include "irsaFiles" . | nindent 4 }}
     {{- include "awsNtpFiles" . | nindent 4 }}
-    {{- if .Values.proxy.enabled }}{{- include "proxyFiles" . | nindent 4 }}{{- end }}
+    {{- if .Values.connectivity.proxy.enabled }}{{- include "proxyFiles" . | nindent 4 }}{{- end }}
     {{- include "kubernetesFiles" . | nindent 4 }}
     {{- include "registryFiles" . | nindent 4 }}
     initConfiguration:
@@ -188,7 +188,7 @@ spec:
     {{- include "prepare-varLibKubelet-Dir" . | nindent 4 }}
     {{- include "diskPreKubeadmCommands" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
-    {{- if .Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
+    {{- if .Values.connectivity.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
     {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
     {{- include "awsNtpPostKubeadmCommands" . | nindent 4 }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -83,12 +83,12 @@ room for such suffix.
   content: {{ tpl ($.Files.Get "files/http-proxy.conf") $ | b64enc }}
 {{- end -}}
 {{- define "proxyCommand" -}}
-- export HTTP_PROXY={{ $.Values.proxy.http_proxy }}
-- export HTTPS_PROXY={{ $.Values.proxy.https_proxy }}
-- export NO_PROXY=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.proxy.no_proxy }}
-- export http_proxy={{ $.Values.proxy.http_proxy }}
-- export https_proxy={{ $.Values.proxy.https_proxy }}
-- export no_proxy=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.proxy.no_proxy }}
+- export HTTP_PROXY={{ $.Values.connectivity.proxy.httpProxy }}
+- export HTTPS_PROXY={{ $.Values.connectivity.proxy.httpsProxy }}
+- export NO_PROXY=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}
+- export http_proxy={{ $.Values.connectivity.proxy.httpProxy }}
+- export https_proxy={{ $.Values.connectivity.proxy.httpsProxy }}
+- export no_proxy=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.network.vpcCIDR }},{{ $.Values.network.serviceCIDR }},{{ $.Values.network.podCIDR }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}
 - systemctl daemon-reload
 - systemctl restart containerd
 - systemctl restart kubelet

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -98,14 +98,14 @@ spec:
   preKubeadmCommands:
     {{- include "prepare-varLibKubelet-Dir" . | nindent 4 }}
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
-    {{- if $.Values.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
+    {{- if $.Values.connectivity.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
   postKubeadmCommands:
     {{- include "awsNtpPostKubeadmCommands" . | nindent 4 }}
   users:
   {{- include "sshUsers" . | nindent 2 }}
   files:
   {{- include "sshFiles" $ | nindent 2 }}
-  {{- if $.Values.proxy.enabled }}{{- include "proxyFiles" $ | nindent 2 }}{{- end }}
+  {{- if $.Values.connectivity.proxy.enabled }}{{- include "proxyFiles" $ | nindent 2 }}{{- end }}
   {{- include "registryFiles" $ | nindent 2 }}
   {{- include "awsNtpFiles" $ | nindent 2 }}
 ---

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -192,6 +192,32 @@
                     "description": "Endpoints and credentials configuration for container registries.",
                     "title": "Container registries",
                     "type": "object"
+                },
+                "proxy": {
+                    "description": "Whether/how outgoing traffic is routed through proxy servers.",
+                    "properties": {
+                        "enabled": {
+                            "title": "Enable",
+                            "type": "boolean"
+                        },
+                        "httpProxy": {
+                            "description": "To be passed to the HTTP_PROXY environment variable in all hosts.",
+                            "title": "HTTP proxy",
+                            "type": "string"
+                        },
+                        "httpsProxy": {
+                            "description": "To be passed to the HTTPS_PROXY environment variable in all hosts.",
+                            "title": "HTTPS proxy",
+                            "type": "string"
+                        },
+                        "noProxy": {
+                            "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                            "title": "No proxy",
+                            "type": "string"
+                        }
+                    },
+                    "title": "Proxy",
+                    "type": "object"
                 }
             },
             "title": "Connectivity",
@@ -634,32 +660,6 @@
                 }
             },
             "title": "AWS settings",
-            "type": "object"
-        },
-        "proxy": {
-            "description": "Whether/how outgoing traffic is routed through proxy servers.",
-            "properties": {
-                "enabled": {
-                    "title": "Enable",
-                    "type": "boolean"
-                },
-                "http_proxy": {
-                    "description": "To be passed to the HTTP_PROXY environment variable in all hosts.",
-                    "title": "HTTP proxy",
-                    "type": "string"
-                },
-                "https_proxy": {
-                    "description": "To be passed to the HTTPS_PROXY environment variable in all hosts.",
-                    "title": "HTTPS proxy",
-                    "type": "string"
-                },
-                "no_proxy": {
-                    "description": "To be passed to the NO_PROXY environment variable in all hosts.",
-                    "title": "No proxy",
-                    "type": "string"
-                }
-            },
-            "title": "Proxy",
             "type": "object"
         },
         "sshSSOPublicKey": {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -3,7 +3,8 @@ bastion:
   enabled: true
   instanceType: t3.small
   replicas: 1
-connectivity: {}
+connectivity:
+  proxy: {}
 controlPlane:
   containerdVolumeSizeGB: 100
   etcdVolumeSizeGB: 100
@@ -60,5 +61,4 @@ network:
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"
-proxy: {}
 sshSSOPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This moves the /proxy values into the /connectivity section.

In addition, property names are changed to camelCase consistency reasons:

- Rename `no_proxy` to `noProxy`
- Rename `http_proxy` to `httpProxy`
- Rename `https_proxy` to `httpsProxy`

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
