### PR TITLE
Remove /aws/awsClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Rename /proxy/http_proxy to /connectivity/proxy/httpProxy
     - Rename /proxy/https_proxy to /connectivity/proxy/httpsProxy
   - Move /sshSSOPublicKey to /connectivity/sshSsoPublicKey
+  - Remove /aws/awsClusterRole (previously deprecated)
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -30,10 +30,6 @@ spec:
     kind: AWSClusterRoleIdentity
     {{- with .Values.providerSpecific.awsClusterRoleIdentityName }}
     name: {{ . | quote }}
-    {{- else }}
-    {{- with .Values.aws.awsClusterRole }}
-    name: {{ . | quote }}
-    {{- end }}
     {{- end }}
   controlPlaneLoadBalancer:
     scheme: {{ if (eq .Values.network.apiMode "public") }}internet-facing{{ else }}internal{{ end }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -92,18 +92,6 @@
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "aws": {
-            "properties": {
-                "awsClusterRole": {
-                    "$comment": "Please use /providerSpecific/awsClusterRoleIdentityName.",
-                    "deprecated": true,
-                    "title": "Cluster role",
-                    "type": "string"
-                }
-            },
-            "title": "AWS settings",
-            "type": "object"
-        },
         "baseDomain": {
             "title": "Base DNS domain",
             "type": "string"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,4 +1,3 @@
-aws: {}
 connectivity:
   bastion:
     enabled: true


### PR DESCRIPTION
### What this PR does / why we need it

Using the occasion to remove value `/aws/awsClusterRole` from schema, which has been replaced in the meantime with `/providerSpecific/awsClusterRoleIdentityName`.

### Checklist

- [x] Update changelog in CHANGELOG.md.


