### PR TITLE
Remove /includeClusterResourceSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Rename /proxy/http_proxy to /connectivity/proxy/httpProxy
     - Rename /proxy/https_proxy to /connectivity/proxy/httpsProxy
   - Move /sshSSOPublicKey to /connectivity/sshSsoPublicKey
+  - Remove unused /includeClusterResourceSet
 
 ### Fixed
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -387,11 +387,6 @@
             "title": "Hash salt",
             "type": "string"
         },
-        "includeClusterResourceSet": {
-            "default": true,
-            "title": "Include ClusterResourceSet",
-            "type": "boolean"
-        },
         "kubectlImage": {
             "properties": {
                 "name": {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -28,7 +28,6 @@ defaultMachinePools:
       - label=default
     instanceType: m5.xlarge
     minSize: 3
-includeClusterResourceSet: true
 kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io


### PR DESCRIPTION
### What this PR does / why we need it

Removes /includeClusterResourceSet, which is ineffectve. The implementation in cluster-shared is done in a way that it's not possible to overwrite the value. Also once effective, the setting should placed in one of the standard objects of the schema.

We removed it for the same reasons from Azure: https://github.com/giantswarm/cluster-azure/pull/61

### Checklist

- [x] Update changelog in CHANGELOG.md.
