### PR TITLE
Create /internal object with initial set of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /sshSSOPublicKey to /connectivity/sshSsoPublicKey
   - Remove unused /includeClusterResourceSet
   - Remove /aws/awsClusterRole (previously deprecated)
+  - Move /hashSalt to /internal/hashSalt
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove unused /includeClusterResourceSet
   - Remove /aws/awsClusterRole (previously deprecated)
   - Move /hashSalt to /internal/hashSalt
+  - Move /kubernetesVersion to /internal/kubernetesVersion
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -84,7 +84,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
         name: {{ include "resource.default.name" $ }}-bastion-{{ include "hash" (dict "data" (include "bastion-awsmachinetemplate-spec" $) "global" .) }}
-      version: {{ .Values.kubernetesVersion }}
+      version: {{ .Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -195,7 +195,7 @@ spec:
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: {{ .Values.controlPlane.replicas | default "3" }}
-  version: v{{ trimPrefix "v" .Values.kubernetesVersion }}
+  version: v{{ trimPrefix "v" .Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -186,6 +186,6 @@ Where `data` is the data to has on and `global` is the top level scope.
 {{- define "hash" -}}
 {{- $data := mustToJson .data | toString  }}
 {{- $salt := "" }}
-{{- if .global.Values.hashSalt }}{{ $salt = .global.Values.hashSalt}}{{end}}
+{{- if .global.Values.internal.hashSalt }}{{ $salt = .global.Values.internal.hashSalt}}{{end}}
 {{- (printf "%s%s" $data $salt) | quote | sha1sum | trunc 8 }}
 {{- end -}}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -25,7 +25,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachinePool
         name: {{ include "resource.default.name" $ }}-{{ $name }}
-      version: {{ $.Values.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachinePool

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -370,10 +370,17 @@
             "title": "Default node pool",
             "type": "object"
         },
-        "hashSalt": {
-            "description": "If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.",
-            "title": "Hash salt",
-            "type": "string"
+        "internal": {
+            "description": "For Giant Swarm internal use only, not stable, or not supported by UIs.",
+            "properties": {
+                "hashSalt": {
+                    "description": "If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.",
+                    "title": "Hash salt",
+                    "type": "string"
+                }
+            },
+            "title": "Internal",
+            "type": "object"
         },
         "kubectlImage": {
             "properties": {

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -377,6 +377,14 @@
                     "description": "If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.",
                     "title": "Hash salt",
                     "type": "string"
+                },
+                "kubernetesVersion": {
+                    "default": "1.23.16",
+                    "examples": [
+                        "1.24.7"
+                    ],
+                    "title": "Kubernetes version",
+                    "type": "string"
                 }
             },
             "title": "Internal",
@@ -402,14 +410,6 @@
             },
             "title": "Kubectl image",
             "type": "object"
-        },
-        "kubernetesVersion": {
-            "default": "1.23.16",
-            "examples": [
-                "1.24.7"
-            ],
-            "title": "Kubernetes version",
-            "type": "string"
         },
         "machinePools": {
             "patternProperties": {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -27,6 +27,7 @@ defaultMachinePools:
       - label=default
     instanceType: m5.xlarge
     minSize: 3
+internal: {}
 kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -27,12 +27,12 @@ defaultMachinePools:
       - label=default
     instanceType: m5.xlarge
     minSize: 3
-internal: {}
+internal:
+  kubernetesVersion: 1.23.16
 kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io
   tag: 1.23.5
-kubernetesVersion: 1.23.16
 metadata: {}
 network:
   apiMode: public


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This PR moves first properties into the /internal object, which is dedicated to settings that are meant for Giant Swarm staff only, or which should not exposed via user interfaces, or which are considered unstable/experimental.

### Checklist

- [x] Update changelog in CHANGELOG.md.
