### PR TITLE
Move DNS-related properties to /connectivity/dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /sshSSOPublicKey to /connectivity/sshSsoPublicKey
   - Remove unused /includeClusterResourceSet
   - Remove /aws/awsClusterRole (previously deprecated)
+  - Move /network/dnsMode to /connectivity/dns/mode
+  - Move /network/dnsAssignAdditionalVPCs to /connectivity/dns/additionalVpc and change to type array
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -1,15 +1,17 @@
 {{- define "aws-cluster" }}
-{{- if and (regexMatch "\\.internal$" (required "baseDomain is required" .Values.baseDomain)) (eq (required "network.dnsMode required" .Values.network.dnsMode) "public") }}
-{{- fail "dnsMode=public cannot be combined with a '*.internal' baseDomain since reserved-as-private TLDs are not propagated to public DNS servers and therefore crucial DNS records such as api.<baseDomain> cannot be looked up" }}
+{{- if and (regexMatch "\\.internal$" (required "baseDomain is required" .Values.baseDomain)) (eq (required "connectivity.dns.mode required" .Values.connectivity.dns.mode) "public") }}
+{{- fail "connectivity.dns.mode=public cannot be combined with a '*.internal' baseDomain since reserved-as-private TLDs are not propagated to public DNS servers and therefore crucial DNS records such as api.<baseDomain> cannot be looked up" }}
 {{- end }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   annotations:
     aws.giantswarm.io/vpc-mode: "{{ .Values.network.vpcMode }}"
-    aws.giantswarm.io/dns-mode: {{ if (eq .Values.network.dnsMode "private") }}"private"{{ else }}"public"{{ end }}
-    {{- if (eq .Values.network.dnsMode "private") }}
-    aws.giantswarm.io/dns-assign-additional-vpc: "{{ .Values.network.dnsAssignAdditionalVPCs }}"
+    aws.giantswarm.io/dns-mode: {{ if (eq .Values.connectivity.dns.mode "private") }}"private"{{ else }}"public"{{ end }}
+    {{- if (eq .Values.connectivity.dns.mode "private") }}
+    {{- with .Values.connectivity.dns.additionalVpc }}
+    aws.giantswarm.io/dns-assign-additional-vpc: {{ . | join "," | quote }}
+    {{- end }}
     {{- end }}
     {{- if .Values.network.resolverRulesOwnerAccount }}
     aws.giantswarm.io/resolver-rules-owner-account: "{{ .Values.network.resolverRulesOwnerAccount }}"

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -181,6 +181,35 @@
                     "title": "Container registries",
                     "type": "object"
                 },
+                "dns": {
+                    "properties": {
+                        "additionalVpc": {
+                            "description": "If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.",
+                            "items": {
+                                "examples": [
+                                    "vpc-x2aeasd1d"
+                                ],
+                                "pattern": "^vpc-[0-0a-zA-Z]+$",
+                                "title": "VPC identifier",
+                                "type": "string"
+                            },
+                            "title": "Additional VPCs",
+                            "type": "array"
+                        },
+                        "mode": {
+                            "default": "public",
+                            "description": "Whether the Route53 hosted zone of this cluster should be public or private.",
+                            "enum": [
+                                "public",
+                                "private"
+                            ],
+                            "title": "Mode",
+                            "type": "string"
+                        }
+                    },
+                    "title": "DNS",
+                    "type": "object"
+                },
                 "network": {
                     "properties": {
                         "podCidr": {
@@ -450,25 +479,6 @@
                     "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
                     "title": "Availability zones",
                     "type": "integer"
-                },
-                "dnsAssignAdditionalVPCs": {
-                    "description": "If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone. Separate multiple entries with comma.",
-                    "examples": [
-                        "vpc-98injA",
-                        "vpc-x2aeasd1d,vpc-98injA"
-                    ],
-                    "title": "DNS assign additional VPCs",
-                    "type": "string"
-                },
-                "dnsMode": {
-                    "default": "public",
-                    "description": "Whether the Route53 hosted zone of this cluster should be public or private.",
-                    "enum": [
-                        "public",
-                        "private"
-                    ],
-                    "title": "DNS mode",
-                    "type": "string"
                 },
                 "prefixListID": {
                     "description": "ID of the managed prefix list to use when the topology mode is set to 'UserManaged'.",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -3,6 +3,8 @@ connectivity:
     enabled: true
     instanceType: t3.small
     replicas: 1
+  dns:
+    mode: public
   network:
     podCidr: 100.64.0.0/12
     serviceCidr: 172.31.0.0/16
@@ -36,7 +38,6 @@ metadata: {}
 network:
   apiMode: public
   availabilityZoneUsageLimit: 3
-  dnsMode: public
   subnets:
     - cidrBlocks:
         - availabilityZone: a


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This PR

- Moves two DNS related properties into the object `/connectivity/dns`
- Modifies property names to benefit from the nesting
- Changes property type for `additionalVpc` to `array` and adapts the template accordingly, to simplify entry through end users

### Checklist

- [x] Update changelog in CHANGELOG.md.
