### PR TITLE
Forbid additional properties on the root level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /kubernetesVersion to /internal/kubernetesVersion
   - Move /network/dnsMode to /connectivity/dns/mode
   - Move /network/dnsAssignAdditionalVPCs to /connectivity/dns/additionalVpc and change to type array
+  - Disallow additional properties on the root level
 
 ### Fixed
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -91,6 +91,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
     "properties": {
         "baseDomain": {
             "title": "Base DNS domain",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -97,6 +97,10 @@
             "title": "Base DNS domain",
             "type": "string"
         },
+        "cluster-shared": {
+            "title": "Library chart",
+            "type": "object"
+        },
         "connectivity": {
             "properties": {
                 "bastion": {


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2168

Cluster app values schemas must not allow arbitrary values on the root level, so that our user interface presents a clean overview of all properties in their categories.

This PR disallows arbitrary root level propoerties and makes the required schema changes to keep the chart valid.

### Checklist

- [x] Update changelog in CHANGELOG.md.

