### PR TITLE
Move /network/apiMode to /controlPlane/apiMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /kubernetesVersion to /internal/kubernetesVersion
   - Move /network/dnsMode to /connectivity/dns/mode
   - Move /network/dnsAssignAdditionalVPCs to /connectivity/dns/additionalVpc and change to type array
+  - Move /network/apiMode to /controlPlane/apiMode
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -34,7 +34,7 @@ spec:
     name: {{ . | quote }}
     {{- end }}
   controlPlaneLoadBalancer:
-    scheme: {{ if (eq .Values.network.apiMode "public") }}internet-facing{{ else }}internal{{ end }}
+    scheme: {{ if (eq .Values.controlPlane.apiMode "public") }}internet-facing{{ else }}internal{{ end }}
   network:
     cni:
       cniIngressRules:

--- a/helm/cluster-aws/templates/_validation.tpl
+++ b/helm/cluster-aws/templates/_validation.tpl
@@ -5,8 +5,8 @@ Instead this is used to perform some validation checks on values that dont make 
 */}}
 
 {{/* Ensure that vpcMode and apiMode values are compatible with each other */}}
-{{ if and (eq .Values.network.vpcMode "private") (eq .Values.network.apiMode "public") }}
-{{- fail "`.Values.network.apiMode` cannot be 'public' if `.Values.network.vpcMode` is set to 'private'" }}
+{{ if and (eq .Values.network.vpcMode "private") (eq .Values.controlPlane.apiMode "public") }}
+{{- fail "`.Values.controlPlane.apiMode` cannot be 'public' if `.Values.network.vpcMode` is set to 'private'" }}
 {{ end }}
 
 {{- end -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -265,6 +265,16 @@
         },
         "controlPlane": {
             "properties": {
+                "apiMode": {
+                    "default": "public",
+                    "description": "Whether the Kubernetes API server load balancer should be reachable from the internet (public) or internal only (private).",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "title": "API mode",
+                    "type": "string"
+                },
                 "containerdVolumeSizeGB": {
                     "default": 100,
                     "title": "Containerd volume size (GB)",
@@ -471,16 +481,6 @@
         },
         "network": {
             "properties": {
-                "apiMode": {
-                    "default": "public",
-                    "description": "Whether the Kubernetes API server load balancer should be reachable from the internet (public) or internal only (private).",
-                    "enum": [
-                        "public",
-                        "private"
-                    ],
-                    "title": "API mode",
-                    "type": "string"
-                },
                 "availabilityZoneUsageLimit": {
                     "default": 3,
                     "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -11,6 +11,7 @@ connectivity:
   proxy: {}
   sshSsoPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
+  apiMode: public
   containerdVolumeSizeGB: 100
   etcdVolumeSizeGB: 100
   instanceType: m5.xlarge
@@ -37,7 +38,6 @@ kubectlImage:
   tag: 1.23.5
 metadata: {}
 network:
-  apiMode: public
   availabilityZoneUsageLimit: 3
   subnets:
     - cidrBlocks:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This moves the `apiMode` property into the `/controlPlane` top level section.

### Checklist

- [x] Update changelog in CHANGELOG.md.
