### PR TITLE
Move remaining network properties into /connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/topologyMode to /connectivity/topology/mode
   - Move /network/transitGatewayID to /connectivity/topology/transitGatewayId
   - Move /network/vpcEndpointMode to /connectivity/vpcEndpointMode
+  - Move /network/vpcMode to /connectivity/vpcMode
   - Disallow additional properties on the root level
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/transitGatewayID to /connectivity/topology/transitGatewayId
   - Move /network/vpcEndpointMode to /connectivity/vpcEndpointMode
   - Move /network/vpcMode to /connectivity/vpcMode
+  - Move /network/availabilityZoneUsageLimit to /connectivity/availabilityZoneUsageLimit
   - Disallow additional properties on the root level
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/prefixListID to /connectivity/topology/prefixListId
   - Move /network/topologyMode to /connectivity/topology/mode
   - Move /network/transitGatewayID to /connectivity/topology/transitGatewayId
+  - Move /network/vpcEndpointMode to /connectivity/vpcEndpointMode
   - Disallow additional properties on the root level
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/vpcEndpointMode to /connectivity/vpcEndpointMode
   - Move /network/vpcMode to /connectivity/vpcMode
   - Move /network/availabilityZoneUsageLimit to /connectivity/availabilityZoneUsageLimit
+  - Move /network/subnets to /connectivity/subnets
   - Disallow additional properties on the root level
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ connectivity:
   availabilityZoneUsageLimit: 3
   network:
     vpcCidr: 10.0.0.0/16
-network:
   subnets:
   # Control plane nodes subnets
   - cidrBlocks:

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Subnet groupings can be defined by setting `.network.subnets`. For example, to h
 
 ```yaml
 connectivity:
+  availabilityZoneUsageLimit: 3
   network:
     vpcCidr: 10.0.0.0/16
 network:
-  availabilityZoneUsageLimit: 3
   subnets:
   # Control plane nodes subnets
   - cidrBlocks:

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -43,7 +43,7 @@ spec:
         protocol: "-1"
         toPort: -1
     vpc:
-      availabilityZoneUsageLimit: {{ .Values.network.availabilityZoneUsageLimit }}
+      availabilityZoneUsageLimit: {{ .Values.connectivity.availabilityZoneUsageLimit }}
       cidrBlock: {{ .Values.connectivity.network.vpcCidr }}
     subnets:
     {{- range $j, $subnet := .Values.network.subnets }}

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -20,7 +20,7 @@ metadata:
     cluster.x-k8s.io/paused: "true"
     {{end}}
     aws.cluster.x-k8s.io/external-resource-gc: "true"
-    aws.giantswarm.io/vpc-endpoint-mode: "{{ .Values.network.vpcEndpointMode }}"
+    aws.giantswarm.io/vpc-endpoint-mode: "{{ .Values.connectivity.vpcEndpointMode }}"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -46,7 +46,7 @@ spec:
       availabilityZoneUsageLimit: {{ .Values.connectivity.availabilityZoneUsageLimit }}
       cidrBlock: {{ .Values.connectivity.network.vpcCidr }}
     subnets:
-    {{- range $j, $subnet := .Values.network.subnets }}
+    {{- range $j, $subnet := .Values.connectivity.subnets }}
     {{- range $i, $cidr := $subnet.cidrBlocks }}
     - cidrBlock: "{{ $cidr.cidr }}"
       {{- if eq (len $cidr.availabilityZone) 1 }}

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -6,7 +6,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   annotations:
-    aws.giantswarm.io/vpc-mode: "{{ .Values.network.vpcMode }}"
+    aws.giantswarm.io/vpc-mode: "{{ .Values.connectivity.vpcMode }}"
     aws.giantswarm.io/dns-mode: {{ if (eq .Values.connectivity.dns.mode "private") }}"private"{{ else }}"public"{{ end }}
     {{- if (eq .Values.connectivity.dns.mode "private") }}
     {{- with .Values.connectivity.dns.additionalVpc }}
@@ -16,7 +16,7 @@ metadata:
     {{- if .Values.connectivity.dns.resolverRulesOwnerAccount }}
     aws.giantswarm.io/resolver-rules-owner-account: "{{ .Values.connectivity.dns.resolverRulesOwnerAccount }}"
     {{- end}}
-    {{- if (eq .Values.network.vpcMode "private") }}
+    {{- if (eq .Values.connectivity.vpcMode "private") }}
     cluster.x-k8s.io/paused: "true"
     {{end}}
     aws.cluster.x-k8s.io/external-resource-gc: "true"

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -15,15 +15,15 @@ template:
       insecureSkipSecretsManager: true
     imageLookupFormat: Flatcar-stable-*
     imageLookupOrg: "{{ .Values.providerSpecific.flatcarAwsAccount }}"
-    publicIP: {{ if eq .Values.network.vpcMode "private" }}false{{else}}true{{end}}
+    publicIP: {{ if eq .Values.connectivity.vpcMode "private" }}false{{else}}true{{end}}
     sshKeyName: ""
     uncompressedUserData: true
     subnet:
       filters:
-        - name: tag:{{ if eq .Values.network.vpcMode "private" }}github.com/giantswarm/aws-vpc-operator/role{{else}}sigs.k8s.io/cluster-api-provider-aws/role{{end}}
+        - name: tag:{{ if eq .Values.connectivity.vpcMode "private" }}github.com/giantswarm/aws-vpc-operator/role{{else}}sigs.k8s.io/cluster-api-provider-aws/role{{end}}
           values:
-          - {{ if eq .Values.network.vpcMode "private" }}private{{else}}public{{end}}
-        - name: tag:{{ if eq .Values.network.vpcMode "private" }}github.com/giantswarm/aws-vpc-operator/{{else}}sigs.k8s.io/cluster-api-provider-aws/cluster/{{end}}{{ include "resource.default.name" $ }}
+          - {{ if eq .Values.connectivity.vpcMode "private" }}private{{else}}public{{end}}
+        - name: tag:{{ if eq .Values.connectivity.vpcMode "private" }}github.com/giantswarm/aws-vpc-operator/{{else}}sigs.k8s.io/cluster-api-provider-aws/cluster/{{end}}{{ include "resource.default.name" $ }}
           values:
           - owned
           - shared

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -34,7 +34,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
     name: {{ include "resource.default.name" $ }}
-  {{- if (eq .Values.network.vpcMode "private") }}
+  {{- if (eq .Values.connectivity.vpcMode "private") }}
   paused: true
   {{- end -}}
 {{- end -}}

--- a/helm/cluster-aws/templates/_validation.tpl
+++ b/helm/cluster-aws/templates/_validation.tpl
@@ -5,8 +5,8 @@ Instead this is used to perform some validation checks on values that dont make 
 */}}
 
 {{/* Ensure that vpcMode and apiMode values are compatible with each other */}}
-{{ if and (eq .Values.network.vpcMode "private") (eq .Values.controlPlane.apiMode "public") }}
-{{- fail "`.Values.controlPlane.apiMode` cannot be 'public' if `.Values.network.vpcMode` is set to 'private'" }}
+{{ if and (eq .Values.connectivity.vpcMode "private") (eq .Values.controlPlane.apiMode "public") }}
+{{- fail "`.Values.controlPlane.apiMode` cannot be 'public' if `.Values.connectivity.vpcMode` is set to 'private'" }}
 {{ end }}
 
 {{- end -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -320,6 +320,16 @@
                     ],
                     "title": "VPC endpoint mode",
                     "type": "string"
+                },
+                "vpcMode": {
+                    "default": "public",
+                    "description": "Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).",
+                    "enum": [
+                        "public",
+                        "private"
+                    ],
+                    "title": "VPC mode",
+                    "type": "string"
                 }
             },
             "title": "Connectivity",
@@ -648,16 +658,6 @@
                     },
                     "title": "Subnets",
                     "type": "array"
-                },
-                "vpcMode": {
-                    "default": "public",
-                    "description": "Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).",
-                    "enum": [
-                        "public",
-                        "private"
-                    ],
-                    "title": "VPC mode",
-                    "type": "string"
                 }
             },
             "title": "Network",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -103,6 +103,12 @@
         },
         "connectivity": {
             "properties": {
+                "availabilityZoneUsageLimit": {
+                    "default": 3,
+                    "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
+                    "title": "Availability zones",
+                    "type": "integer"
+                },
                 "bastion": {
                     "properties": {
                         "enabled": {
@@ -553,12 +559,6 @@
         },
         "network": {
             "properties": {
-                "availabilityZoneUsageLimit": {
-                    "default": 3,
-                    "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
-                    "title": "Availability zones",
-                    "type": "integer"
-                },
                 "subnets": {
                     "default": [
                         {

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -310,6 +310,16 @@
                     },
                     "title": "Topology",
                     "type": "object"
+                },
+                "vpcEndpointMode": {
+                    "default": "GiantSwarmManaged",
+                    "description": "Who is reponsible for creation and management of VPC endpoints.",
+                    "enum": [
+                        "GiantSwarmManaged",
+                        "UserManaged"
+                    ],
+                    "title": "VPC endpoint mode",
+                    "type": "string"
                 }
             },
             "title": "Connectivity",
@@ -638,16 +648,6 @@
                     },
                     "title": "Subnets",
                     "type": "array"
-                },
-                "vpcEndpointMode": {
-                    "default": "GiantSwarmManaged",
-                    "description": "Who is reponsible for creation and management of VPC endpoints.",
-                    "enum": [
-                        "GiantSwarmManaged",
-                        "UserManaged"
-                    ],
-                    "title": "VPC endpoint mode",
-                    "type": "string"
                 },
                 "vpcMode": {
                     "default": "public",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -289,6 +289,94 @@
                     "title": "SSH public key for single sign-on",
                     "type": "string"
                 },
+                "subnets": {
+                    "default": [
+                        {
+                            "cidrBlocks": [
+                                {
+                                    "availabilityZone": "a",
+                                    "cidr": "10.0.0.0/20"
+                                },
+                                {
+                                    "availabilityZone": "b",
+                                    "cidr": "10.0.16.0/20"
+                                },
+                                {
+                                    "availabilityZone": "c",
+                                    "cidr": "10.0.32.0/20"
+                                }
+                            ],
+                            "isPublic": true
+                        },
+                        {
+                            "cidrBlocks": [
+                                {
+                                    "availabilityZone": "a",
+                                    "cidr": "10.0.64.0/18"
+                                },
+                                {
+                                    "availabilityZone": "b",
+                                    "cidr": "10.0.128.0/18"
+                                },
+                                {
+                                    "availabilityZone": "c",
+                                    "cidr": "10.0.192.0/18"
+                                }
+                            ],
+                            "isPublic": false
+                        }
+                    ],
+                    "items": {
+                        "properties": {
+                            "cidrBlocks": {
+                                "items": {
+                                    "properties": {
+                                        "availabilityZone": {
+                                            "examples": [
+                                                "a"
+                                            ],
+                                            "title": "Availability zone",
+                                            "type": "string"
+                                        },
+                                        "cidr": {
+                                            "description": "IPv4 address range, in CIDR notation.",
+                                            "title": "Address range",
+                                            "type": "string"
+                                        },
+                                        "tags": {
+                                            "additionalProperties": {
+                                                "$ref": "#/$defs/awsResourceTagValue"
+                                            },
+                                            "description": "AWS resource tags to assign to this subnet.",
+                                            "title": "Tags",
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "title": "Network",
+                                "type": "array"
+                            },
+                            "isPublic": {
+                                "title": "Public",
+                                "type": "boolean"
+                            },
+                            "tags": {
+                                "additionalProperties": {
+                                    "$ref": "#/$defs/awsResourceTagValue"
+                                },
+                                "description": "AWS resource tags to assign to this CIDR block.",
+                                "title": "Tags",
+                                "type": "object"
+                            }
+                        },
+                        "title": "Subnet",
+                        "type": "object"
+                    },
+                    "title": "Subnets",
+                    "description": "Subnets are created and tagged based on this definition.",
+                    "type": "array"
+                },
                 "topology": {
                     "description": "Networking architecture between management cluster and workload cluster.",
                     "properties": {
@@ -555,99 +643,6 @@
                 }
             },
             "title": "Metadata",
-            "type": "object"
-        },
-        "network": {
-            "properties": {
-                "subnets": {
-                    "default": [
-                        {
-                            "cidrBlocks": [
-                                {
-                                    "availabilityZone": "a",
-                                    "cidr": "10.0.0.0/20"
-                                },
-                                {
-                                    "availabilityZone": "b",
-                                    "cidr": "10.0.16.0/20"
-                                },
-                                {
-                                    "availabilityZone": "c",
-                                    "cidr": "10.0.32.0/20"
-                                }
-                            ],
-                            "isPublic": true
-                        },
-                        {
-                            "cidrBlocks": [
-                                {
-                                    "availabilityZone": "a",
-                                    "cidr": "10.0.64.0/18"
-                                },
-                                {
-                                    "availabilityZone": "b",
-                                    "cidr": "10.0.128.0/18"
-                                },
-                                {
-                                    "availabilityZone": "c",
-                                    "cidr": "10.0.192.0/18"
-                                }
-                            ],
-                            "isPublic": false
-                        }
-                    ],
-                    "items": {
-                        "properties": {
-                            "cidrBlocks": {
-                                "items": {
-                                    "properties": {
-                                        "availabilityZone": {
-                                            "examples": [
-                                                "a"
-                                            ],
-                                            "title": "Availability zone",
-                                            "type": "string"
-                                        },
-                                        "cidr": {
-                                            "description": "IPv4 address range, in CIDR notation.",
-                                            "title": "Address range",
-                                            "type": "string"
-                                        },
-                                        "tags": {
-                                            "additionalProperties": {
-                                                "$ref": "#/$defs/awsResourceTagValue"
-                                            },
-                                            "description": "AWS resource tags to assign to this subnet.",
-                                            "title": "Tags",
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "title": "Network",
-                                "type": "array"
-                            },
-                            "isPublic": {
-                                "title": "Public",
-                                "type": "boolean"
-                            },
-                            "tags": {
-                                "additionalProperties": {
-                                    "$ref": "#/$defs/awsResourceTagValue"
-                                },
-                                "description": "AWS resource tags to assign to this CIDR block.",
-                                "title": "Tags",
-                                "type": "object"
-                            }
-                        },
-                        "title": "Subnet",
-                        "type": "object"
-                    },
-                    "title": "Subnets",
-                    "type": "array"
-                }
-            },
-            "title": "Network",
             "type": "object"
         },
         "providerSpecific": {

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -326,6 +326,7 @@
                             "isPublic": false
                         }
                     ],
+                    "description": "Subnets are created and tagged based on this definition.",
                     "items": {
                         "properties": {
                             "cidrBlocks": {
@@ -374,7 +375,6 @@
                         "type": "object"
                     },
                     "title": "Subnets",
-                    "description": "Subnets are created and tagged based on this definition.",
                     "type": "array"
                 },
                 "topology": {

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -559,19 +559,6 @@
                     "title": "Availability zones",
                     "type": "integer"
                 },
-                "resolverRulesOwnerAccount": {
-                    "description": "ID of the AWS account that created the resolver rules to be associated with the workload cluster VPC.",
-                    "oneOf": [
-                        {
-                            "pattern": "^\\d{12}$"
-                        },
-                        {
-                            "const": ""
-                        }
-                    ],
-                    "title": "Resolver rules owner",
-                    "type": "string"
-                },
                 "subnets": {
                     "default": [
                         {

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -13,6 +13,8 @@ connectivity:
   sshSsoPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
   topology:
     mode: None
+  vpcEndpointMode: GiantSwarmManaged
+  vpcMode: public
 controlPlane:
   apiMode: public
   containerdVolumeSizeGB: 100
@@ -59,8 +61,6 @@ network:
         - availabilityZone: c
           cidr: 10.0.192.0/18
       isPublic: false
-  vpcEndpointMode: GiantSwarmManaged
-  vpcMode: public
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -1,4 +1,5 @@
 connectivity:
+  availabilityZoneUsageLimit: 3
   bastion:
     enabled: true
     instanceType: t3.small
@@ -43,7 +44,6 @@ kubectlImage:
   tag: 1.23.5
 metadata: {}
 network:
-  availabilityZoneUsageLimit: 3
   subnets:
     - cidrBlocks:
         - availabilityZone: a

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -12,6 +12,23 @@ connectivity:
     vpcCidr: 10.0.0.0/16
   proxy: {}
   sshSsoPublicKey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
+  subnets:
+    - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.0.0.0/20
+        - availabilityZone: b
+          cidr: 10.0.16.0/20
+        - availabilityZone: c
+          cidr: 10.0.32.0/20
+      isPublic: true
+    - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.0.64.0/18
+        - availabilityZone: b
+          cidr: 10.0.128.0/18
+        - availabilityZone: c
+          cidr: 10.0.192.0/18
+      isPublic: false
   topology:
     mode: None
   vpcEndpointMode: GiantSwarmManaged
@@ -43,24 +60,6 @@ kubectlImage:
   registry: quay.io
   tag: 1.23.5
 metadata: {}
-network:
-  subnets:
-    - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.0.0.0/20
-        - availabilityZone: b
-          cidr: 10.0.16.0/20
-        - availabilityZone: c
-          cidr: 10.0.32.0/20
-      isPublic: true
-    - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.0.64.0/18
-        - availabilityZone: b
-          cidr: 10.0.128.0/18
-        - availabilityZone: c
-          cidr: 10.0.192.0/18
-      isPublic: false
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

With this PR, all remaining properties from /network are moved into /connectivity.

### Checklist

- [x] Update changelog in CHANGELOG.md.
