### PR TITLE
Add /managementCluster and /provider to values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/transitGatewayID to /connectivity/topology/transitGatewayId
   - Disallow additional properties on the root level
 
+### Added
+
+- Values schema:
+  - Add /managementCluster and /provider to account for values injected by controllers.
+
 ### Fixed
 
 - Use region defaulting wherever possible, removing `region` from schema.

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -511,6 +511,11 @@
             "title": "Node pools",
             "type": "object"
         },
+        "managementCluster": {
+            "title": "Management cluster",
+            "description": "Name of the Cluster API cluster managing this workload cluster.",
+            "type": "string"
+        },
         "metadata": {
             "properties": {
                 "description": {
@@ -662,6 +667,10 @@
             },
             "title": "Network",
             "type": "object"
+        },
+        "provider": {
+            "title": "Cluster API provider name",
+            "type": "string"
         },
         "providerSpecific": {
             "properties": {


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2168

Because of https://github.com/giantswarm/cluster-aws/pull/252 , the attempt to set arbitrary values on the root level will result in an error. To allow cluster-apps-operator to set these properties, they have to be present in the schema.

### Checklist

- [x] Update changelog in CHANGELOG.md.


