### PR TITLE
Change nodepools schema to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move /network/availabilityZoneUsageLimit to /connectivity/availabilityZoneUsageLimit
   - Move /network/subnets to /connectivity/subnets
   - Disallow additional properties on the root level
+  - Change node pools to use array structure, move to /nodePools
 
 ### Added
 

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -1,14 +1,14 @@
 {{- define "machine-pools" }}
-{{- range $name, $value := .Values.machinePools | default .Values.defaultMachinePools }}
+{{- range $nodePool := .Values.nodePools }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   annotations:
-    machine-pool.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ $name }}
+    machine-pool.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
   labels:
-    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
+    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-{{ $name }}
+  name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   clusterName: {{ include "resource.default.name" $ }}
@@ -19,24 +19,24 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfig
-          name: {{ include "resource.default.name" $ }}-{{ $name }}
+          name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
       clusterName: {{ include "resource.default.name" $ }}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachinePool
-        name: {{ include "resource.default.name" $ }}-{{ $name }}
+        name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
       version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachinePool
 metadata:
   labels:
-    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
+    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-{{ $name }}
+  name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
+  availabilityZones: {{ include "aws-availability-zones" $nodePool | nindent 2 }}
   subnets:
   - filters:
     - name: tag:kubernetes.io/cluster/{{ include "resource.default.name" $ }}
@@ -50,14 +50,14 @@ spec:
     {{- end }}
   awsLaunchTemplate:
     {{- include "ami" $ | nindent 4 }}
-    iamInstanceProfile: nodes-{{ $name }}-{{ include "resource.default.name" $ }}
-    instanceType: {{ $value.instanceType | default "m5.xlarge" }}
+    iamInstanceProfile: nodes-{{ $nodePool.name }}-{{ include "resource.default.name" $ }}
+    instanceType: {{ $nodePool.instanceType | default "m5.xlarge" }}
     rootVolume:
-      size: {{ $value.rootVolumeSizeGB | default 300 }}
+      size: {{ $nodePool.rootVolumeSizeGB | default 300 }}
       type: gp3
     sshKeyName: ""
-  minSize: {{ $value.minSize | default 1 }}
-  maxSize: {{ $value.maxSize | default 3 }}
+  minSize: {{ $nodePool.minSize | default 1 }}
+  maxSize: {{ $nodePool.maxSize | default 3 }}
   mixedInstancesPolicy:
     instancesDistribution:
       onDemandAllocationStrategy: prioritized
@@ -69,9 +69,9 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
   labels:
-    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
+    giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
     {{- include "labels.common" $ | nindent 4 }}
-  name: {{ include "resource.default.name" $ }}-{{ $name }}
+  name: {{ include "resource.default.name" $ }}-{{ $nodePool.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   joinConfiguration:
@@ -82,13 +82,13 @@ spec:
         healthz-bind-address: 0.0.0.0
         image-pull-progress-deadline: 1m
         node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
-        node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ $name }},{{- join "," $value.customNodeLabels }}
+        node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ $nodePool.name }},{{- join "," $nodePool.customNodeLabels }}
         v: "2"
       name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
-      {{- if $value.customNodeTaints }}
-      {{- if (gt (len $value.customNodeTaints) 0) }}
+      {{- if $nodePool.customNodeTaints }}
+      {{- if (gt (len $nodePool.customNodeTaints) 0) }}
       taints:
-      {{- range $value.customNodeTaints }}
+      {{- range $nodePool.customNodeTaints }}
       - key: {{ .key | quote }}
         value: {{ .value | quote }}
         effect: {{ .effect | quote }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -629,7 +629,7 @@
                         ],
                         "maxLength": 10,
                         "minLength": 5,
-                        "pattern": "^[a-z0-9]$",
+                        "pattern": "^[a-z0-9]+$",
                         "title": "Name",
                         "type": "string"
                     },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -7,87 +7,6 @@
             "pattern": "^[ a-zA-Z0-9\\._:/=+-@]+$",
             "title": "Tag value",
             "type": "string"
-        },
-        "machinePool": {
-            "properties": {
-                "availabilityZones": {
-                    "items": {
-                        "title": "Availability zone",
-                        "type": "string"
-                    },
-                    "title": "Availability zones",
-                    "type": "array"
-                },
-                "customNodeLabels": {
-                    "items": {
-                        "title": "Label",
-                        "type": "string"
-                    },
-                    "title": "Custom node labels",
-                    "type": "array"
-                },
-                "customNodeTaints": {
-                    "items": {
-                        "properties": {
-                            "effect": {
-                                "enum": [
-                                    "NoSchedule",
-                                    "PreferNoSchedule",
-                                    "NoExecute"
-                                ],
-                                "title": "Effect",
-                                "type": "string"
-                            },
-                            "key": {
-                                "title": "Key",
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Value",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "effect",
-                            "key",
-                            "value"
-                        ],
-                        "type": "object"
-                    },
-                    "title": "Custom node taints",
-                    "type": "array"
-                },
-                "instanceType": {
-                    "title": "EC2 instance type",
-                    "type": "string"
-                },
-                "maxSize": {
-                    "title": "Maximum number of nodes",
-                    "type": "integer"
-                },
-                "minSize": {
-                    "title": "Minimum number of nodes",
-                    "type": "integer"
-                },
-                "rootVolumeSizeGB": {
-                    "title": "Root volume size (GB)",
-                    "type": "integer"
-                },
-                "subnetTags": {
-                    "description": "Tags to filter which AWS subnets will be used for this node pool.",
-                    "items": {
-                        "additionalProperties": {
-                            "$ref": "#/$defs/awsResourceTagValue"
-                        },
-                        "title": "Subnet tag",
-                        "type": "object"
-                    },
-                    "title": "Subnet tags",
-                    "type": "array"
-                }
-            },
-            "title": "Node pool",
-            "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -557,24 +476,6 @@
             "title": "Control plane",
             "type": "object"
         },
-        "defaultMachinePools": {
-            "default": {
-                "def00": {
-                    "customNodeLabels": [
-                        "label=default"
-                    ],
-                    "instanceType": "m5.xlarge",
-                    "minSize": 3
-                }
-            },
-            "patternProperties": {
-                "^[a-z0-9]{5,10}$": {
-                    "$ref": "#/$defs/machinePool"
-                }
-            },
-            "title": "Default node pool",
-            "type": "object"
-        },
         "internal": {
             "description": "For Giant Swarm internal use only, not stable, or not supported by UIs.",
             "properties": {
@@ -616,15 +517,6 @@
             "title": "Kubectl image",
             "type": "object"
         },
-        "machinePools": {
-            "patternProperties": {
-                "^[a-z0-9]{5,10}$": {
-                    "$ref": "#/$defs/machinePool"
-                }
-            },
-            "title": "Node pools",
-            "type": "object"
-        },
         "managementCluster": {
             "description": "Name of the Cluster API cluster managing this workload cluster.",
             "title": "Management cluster",
@@ -649,6 +541,122 @@
             },
             "title": "Metadata",
             "type": "object"
+        },
+        "nodePools": {
+            "default": [
+                {
+                    "customNodeLabels": [
+                        "label=default"
+                    ],
+                    "instanceType": "m5.xlarge",
+                    "maxSize": 3,
+                    "minSize": 3,
+                    "name": "def00"
+                }
+            ],
+            "items": {
+                "properties": {
+                    "availabilityZones": {
+                        "items": {
+                            "title": "Availability zone",
+                            "type": "string"
+                        },
+                        "title": "Availability zones",
+                        "type": "array"
+                    },
+                    "customNodeLabels": {
+                        "items": {
+                            "title": "Label",
+                            "type": "string"
+                        },
+                        "title": "Custom node labels",
+                        "type": "array"
+                    },
+                    "customNodeTaints": {
+                        "items": {
+                            "properties": {
+                                "effect": {
+                                    "enum": [
+                                        "NoSchedule",
+                                        "PreferNoSchedule",
+                                        "NoExecute"
+                                    ],
+                                    "title": "Effect",
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "title": "Key",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "title": "Value",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "effect",
+                                "key",
+                                "value"
+                            ],
+                            "type": "object"
+                        },
+                        "title": "Custom node taints",
+                        "type": "array"
+                    },
+                    "instanceType": {
+                        "title": "EC2 instance type",
+                        "type": "string",
+                        "default": "m5.xlarge"
+                    },
+                    "maxSize": {
+                        "title": "Maximum number of nodes",
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 3
+                    },
+                    "minSize": {
+                        "title": "Minimum number of nodes",
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 1
+                    },
+                    "name": {
+                        "description": "Unique node pool identifier.",
+                        "examples": [
+                            "abc12",
+                            "dev01azure"
+                        ],
+                        "maxLength": 10,
+                        "minLength": 5,
+                        "pattern": "^[a-z0-9]$",
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "rootVolumeSizeGB": {
+                        "title": "Root volume size (GB)",
+                        "type": "integer"
+                    },
+                    "subnetTags": {
+                        "description": "Tags to filter which AWS subnets will be used for this node pool.",
+                        "items": {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/awsResourceTagValue"
+                            },
+                            "title": "Subnet tag",
+                            "type": "object"
+                        },
+                        "title": "Subnet tags",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "title": "Node pool",
+                "type": "object"
+            },
+            "title": "Node pools",
+            "type": "array"
         },
         "provider": {
             "title": "Cluster API provider name",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -604,21 +604,21 @@
                         "type": "array"
                     },
                     "instanceType": {
+                        "default": "m5.xlarge",
                         "title": "EC2 instance type",
-                        "type": "string",
-                        "default": "m5.xlarge"
+                        "type": "string"
                     },
                     "maxSize": {
-                        "title": "Maximum number of nodes",
-                        "type": "integer",
+                        "default": 3,
                         "minimum": 0,
-                        "default": 3
+                        "title": "Maximum number of nodes",
+                        "type": "integer"
                     },
                     "minSize": {
-                        "title": "Minimum number of nodes",
-                        "type": "integer",
+                        "default": 1,
                         "minimum": 0,
-                        "default": 1
+                        "title": "Minimum number of nodes",
+                        "type": "integer"
                     },
                     "name": {
                         "description": "Unique node pool identifier.",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -551,7 +551,8 @@
                     "instanceType": "m5.xlarge",
                     "maxSize": 3,
                     "minSize": 3,
-                    "name": "def00"
+                    "name": "def00",
+                    "rootVolumeSizeGB": 300
                 }
             ],
             "items": {
@@ -633,6 +634,8 @@
                         "type": "string"
                     },
                     "rootVolumeSizeGB": {
+                        "default": 300,
+                        "minimum": 0,
                         "title": "Root volume size (GB)",
                         "type": "integer"
                     },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -61,6 +61,7 @@ nodePools:
     maxSize: 3
     minSize: 3
     name: def00
+    rootVolumeSizeGB: 300
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -47,12 +47,6 @@ controlPlane:
     unhealthyUnknownTimeout: 10m0s
   oidc: {}
   rootVolumeSizeGB: 120
-defaultMachinePools:
-  def00:
-    customNodeLabels:
-      - label=default
-    instanceType: m5.xlarge
-    minSize: 3
 internal:
   kubernetesVersion: 1.23.16
 kubectlImage:
@@ -60,6 +54,13 @@ kubectlImage:
   registry: quay.io
   tag: 1.23.5
 metadata: {}
+nodePools:
+  - customNodeLabels:
+      - label=default
+    instanceType: m5.xlarge
+    maxSize: 3
+    minSize: 3
+    name: def00
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2142

This moves the node pools definition from `/machineDeployments` to `/nodePools`.

As we currently cannot support objects with `patternProperties` in the UI, we also change towards array type.

Additional changes:

- Remove defaultMachinePools, since the default value for /nodePools already includes this
- Set default values for some properties, so that they are exposed in the UI
- Set constraints for some properties, so that some errors are prevented

### Checklist

- [x] Update changelog in CHANGELOG.md.
