### PR TITLE
Fix rendering `oidc.pem` by mistake when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix rendering `oidc.pem` by mistake when not specified
+
 ## [0.29.0] - 2023-03-27
 
 ### Fixed

--- a/helm/cluster-aws/files/etc/ssl/certs/oidc.pem
+++ b/helm/cluster-aws/files/etc/ssl/certs/oidc.pem
@@ -1,3 +1,3 @@
-{{- if ne .Values.controlPlane.oidc.caPem "" -}}
+{{- if .Values.controlPlane.oidc.caPem -}}
 {{ .Values.controlPlane.oidc.caPem }}
 {{- end -}}

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -85,7 +85,7 @@ spec:
           oidc-client-id: {{ .clientId }}
           oidc-username-claim: {{ .usernameClaim }}
           oidc-groups-claim: {{ .groupsClaim }}
-          {{- if ne .caPem "" }}
+          {{- if .caPem }}
           oidc-ca-file: /etc/ssl/certs/oidc.pem
           {{- end }}
           {{- end }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -47,7 +47,7 @@ room for such suffix.
 {{- end -}}
 
 {{- define "oidcFiles" -}}
-{{- if ne .Values.controlPlane.oidc.caPem "" }}
+{{- if .Values.controlPlane.oidc.caPem }}
 - path: /etc/ssl/certs/oidc.pem
   permissions: "0600"
   encoding: base64


### PR DESCRIPTION
### What this PR does / why we need it

https://github.com/giantswarm/giantswarm/issues/26480

The file gets rendered by mistake if the value is `nil` instead of `""`.

Not sure what implications this has, but we already saw some hard errors like `missing content for CA bundle`. Possibly cluster creation is also affected.

PR not tested yet with cluster creation at time of opening it. Will do that now.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
