### PR TITLE
Configure kubelet Shutdown Grace Period 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Configure kubelet `ShutdownGracePeriod` to 5m and `ShutdownGracePeriodCriticalPods` to 1m.
+- Set default Node systemd logind `InhibitDelayMaxSec` to 5m.
+
 ## [0.29.0] - 2023-03-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Configure kubelet `ShutdownGracePeriod` to 5m and `ShutdownGracePeriodCriticalPods` to 1m.
+- Configure kubelet `ShutdownGracePeriod` to 5m and `ShutdownGracePeriodCriticalPods` to 1m. These options let `kubelet` prevent a node from shutting down until it has evicted all the pods from the node. The critical pods will be removed in the last 1m of the total 5m grace period and include pods with their priorityClassName set to system-cluster-critical or system-node-critical.
 - Set default Node systemd logind `InhibitDelayMaxSec` to 5m.
 
 ## [0.29.1] - 2023-04-03

--- a/helm/cluster-aws/files/opt/kubelet-config.sh
+++ b/helm/cluster-aws/files/opt/kubelet-config.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i "s|shutdownGracePeriod: .*|shutdownGracePeriod: 30s|g" "/var/lib/kubelet/config.yaml"
+systemctl restart kubelet

--- a/helm/cluster-aws/files/opt/kubelet-config.sh
+++ b/helm/cluster-aws/files/opt/kubelet-config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-sed -i "s|shutdownGracePeriod: .*|shutdownGracePeriod: 30s|g" "/var/lib/kubelet/config.yaml"
+sed -i "s|shutdownGracePeriod: .*|shutdownGracePeriod: 5m|g" "/var/lib/kubelet/config.yaml"
+sed -i "s|shutdownGracePeriodCriticalPods: .*|shutdownGracePeriodCriticalPods: 1m|g" "/var/lib/kubelet/config.yaml"
 systemctl restart kubelet

--- a/helm/cluster-aws/files/opt/zzz-kubelet-graceful-shutdown.conf
+++ b/helm/cluster-aws/files/opt/zzz-kubelet-graceful-shutdown.conf
@@ -1,0 +1,3 @@
+[Login]
+# delay
+InhibitDelayMaxSec=300

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -144,6 +144,7 @@ spec:
     {{- include "sshFiles" . | nindent 4 }}
     {{- include "diskFiles" . | nindent 4 }}
     {{- include "irsaFiles" . | nindent 4 }}
+    {{- include "kubeletConfigFiles" . | nindent 4 }}
     {{- include "awsNtpFiles" . | nindent 4 }}
     {{- if .Values.connectivity.proxy.enabled }}{{- include "proxyFiles" . | nindent 4 }}{{- end }}
     {{- include "kubernetesFiles" . | nindent 4 }}
@@ -196,6 +197,7 @@ spec:
     {{- if .Values.connectivity.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
     {{- include "irsaPostKubeadmCommands" . | nindent 4 }}
+    {{- include "kubeletConfigPostKubeadmCommands" . | nindent 4 }}
     {{- include "awsNtpPostKubeadmCommands" . | nindent 4 }}
     users:
     {{- include "sshUsers" . | nindent 4 }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -108,6 +108,12 @@ room for such suffix.
   encoding: base64
   content: {{ $.Files.Get "files/opt/irsa-cloudfront.sh" | b64enc }}
 {{- end -}}
+{{- define "kubeletConfigFiles" -}}
+- path: /opt/kubelet-config.sh
+  permissions: "0700"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/kubelet-config.sh" | b64enc }}
+{{- end -}}
 
 {{- define "kubernetesFiles" -}}
 - path: /etc/kubernetes/policies/audit-policy.yaml
@@ -145,6 +151,10 @@ room for such suffix.
 
 {{- define "irsaPostKubeadmCommands" -}}
 - /bin/sh /opt/irsa-cloudfront.sh /etc/kubernetes/manifests/kube-apiserver.yaml
+{{- end -}}
+
+{{- define "kubeletConfigPostKubeadmCommands" -}}
+- /bin/sh /opt/kubelet-config.sh
 {{- end -}}
 
 {{- define "awsNtpPostKubeadmCommands" -}}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -113,6 +113,10 @@ room for such suffix.
   permissions: "0700"
   encoding: base64
   content: {{ $.Files.Get "files/opt/kubelet-config.sh" | b64enc }}
+- path: /lib/systemd/logind.conf.d/zzz-kubelet-graceful-shutdown.conf
+  permissions: "0700"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/zzz-kubelet-graceful-shutdown.conf" | b64enc }}
 {{- end -}}
 
 {{- define "kubernetesFiles" -}}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -105,11 +105,13 @@ spec:
     {{- include "sshPreKubeadmCommands" . | nindent 4 }}
     {{- if $.Values.connectivity.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
   postKubeadmCommands:
+    {{- include "kubeletConfigPostKubeadmCommands" . | nindent 4 }}
     {{- include "awsNtpPostKubeadmCommands" . | nindent 4 }}
   users:
   {{- include "sshUsers" . | nindent 2 }}
   files:
   {{- include "sshFiles" $ | nindent 2 }}
+  {{- include "kubeletConfigFiles" $ | nindent 2 }}
   {{- if $.Values.connectivity.proxy.enabled }}{{- include "proxyFiles" $ | nindent 2 }}{{- end }}
   {{- include "registryFiles" $ | nindent 2 }}
   {{- include "awsNtpFiles" $ | nindent 2 }}


### PR DESCRIPTION
### What this PR does / why we need it

This PR configures both the `shutdownGracePeriod` and `shutdownGracePeriodCriticalPods`. The grace period is set to 5 minutes while the critical pods grace period is set to 1 minute. This means that kubelet will start terminating critical pods (pods with Priority class set to `system-cluster-critical` or `system-node-critical`) in the last 1 minute of the `shutdownGracePeriod`. This is important since our CNI (cilium) is a critical pod that needs to terminated last.

This feature is implemented using [systemd Inhibitor Locs](https://www.freedesktop.org/wiki/Software/systemd/inhibit). The maximum inhibit delay is controlled by the `InhibitDelayMaxSec` in `logind`. On our AWS nodes the default is set to 30 seconds, so we need to override it. This is why the `/lib/systemd/logind.conf.d/zzz-kubelet-graceful-shutdown.conf` is mounted in the nodes (the `zzz` prefix is so it always lands as the last evaluated file).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### References
1. [Graceful Node Shutdown docs](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/)
2. [Graceful Node Shutdown Proposal docs](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2000-graceful-node-shutdown/README.md) (there's some more info on how it works in here)
3. [logind.conf docs](https://www.freedesktop.org/software/systemd/man/logind.conf.html)
4. [systemd inhibit docs](https://www.freedesktop.org/wiki/Software/systemd/inhibit/)


### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
