### PR TITLE
Duplicate label `cluster.x-k8s.io/cluster-name` in MachineDeployent for bastion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove duplicate label ` cluster.x-k8s.io/cluster-name:` in bastion MachineDeployment
+
 ## [0.29.1] - 2023-04-03
 
 ### Fixed

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -73,7 +73,6 @@ spec:
     metadata:
       labels:
         cluster.x-k8s.io/role: bastion
-        cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" $ }}
         cluster.x-k8s.io/deployment-name: {{ include "resource.default.name" $ }}-bastion
         {{- include "labels.common" $ | nindent 8 }}
     spec:


### PR DESCRIPTION
### What this PR does / why we need it

While, rendering helm template as part of https://github.com/giantswarm/talanx/issues/131, noticed that MachineDeployment for bastion has duplicate label.

![Screen Shot 2023-04-06 at 1 11 02 PM](https://user-images.githubusercontent.com/5674762/230305040-95784aa6-0103-4c20-9724-a8b00d6fe03f.png)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
