### PR TITLE
Default to using `giantswarm.azurecr.io` as Docker Hub mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `defaultMachinePools` to `internal.nodePools` to fit new schema requirements and make clear that it should not be changed by customers
+- Default to using `giantswarm.azurecr.io` as Docker Hub mirror
 
 ### Fixed
 

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,3 +1,12 @@
 metadata:
   organization: "test"
 baseDomain: example.com
+
+connectivity:
+  containerRegistries:
+    with-auth.example.com:
+      - endpoint: with-auth.example.com
+        credentials:
+          username: giantswarmpull
+          password: abcdef
+      - endpoint: quay.io

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -188,6 +188,16 @@
                         "title": "Registries",
                         "type": "array"
                     },
+                    "default": {
+                        "docker.io": [
+                            {
+                                "endpoint": "registry-1.docker.io"
+                            },
+                            {
+                                "endpoint": "giantswarm.azurecr.io"
+                            }
+                        ]
+                    },
                     "description": "Endpoints and credentials configuration for container registries.",
                     "title": "Container registries",
                     "type": "object"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -6,6 +6,10 @@ connectivity:
     enabled: true
     instanceType: t3.small
     replicas: 1
+  containerRegistries:
+    docker.io:
+      - endpoint: registry-1.docker.io
+      - endpoint: giantswarm.azurecr.io
   dns:
     mode: public
   network:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/1912

Add mirror endpoint for `docker.io/...` images by default. With this, Docker Hub rate limit errors get hidden (not solved).

I've put the default directly into `connectivity.containerRegistries` instead of introducing a field `internal.defaultContainerRegistries`. That's because we want to _merge_ if customers provide their own. For example, `connectivity: { containerRegistries: { my-harbor.example.com: { ... } } }` is imaginable and should leave our defaults for `docker.io` in place. However, if the key `docker.io` is customized, the value gets overwritten since it's an array.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
