### PR TITLE
Switch from in-tree cloud-controller-manager to external one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable `CronJobTimeZone` feature gate in the kubelet.
 - Set kubernetes `1.24.10` as the default version.
+- Switch from the in-tree cloud-controller-manager to the external one. This requires a minimum version of `default-apps-aws`.
 
 ### Removed
 

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -77,7 +77,7 @@ spec:
           - "api.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
           - 127.0.0.1
         extraArgs:
-          cloud-provider: aws
+          cloud-provider: external
           service-account-issuer: PLACEHOLDER_CLOUDFRONT_DOMAIN
           {{- if .Values.controlPlane.oidc.issuerUrl }}
           {{- with .Values.controlPlane.oidc }}
@@ -124,7 +124,7 @@ spec:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: 0.0.0.0
-          cloud-provider: aws
+          cloud-provider: external
           allocate-node-cidrs: "true"
           cluster-cidr: {{ .Values.connectivity.network.podCidr }}
       scheduler:
@@ -160,7 +160,7 @@ spec:
         bindPort: 0
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
           feature-gates: CronJobTimeZone=true
           healthz-bind-address: 0.0.0.0
           node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
@@ -180,7 +180,7 @@ spec:
       discovery: {}
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: aws
+          cloud-provider: external
           feature-gates: CronJobTimeZone=true
         name: '{{ `{{ ds.meta_data.local_hostname }}` }}'
         {{- if .Values.controlPlane.customNodeTaints }}

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -83,7 +83,7 @@ spec:
     discovery: {}
     nodeRegistration:
       kubeletExtraArgs:
-        cloud-provider: aws
+        cloud-provider: external
         feature-gates: CronJobTimeZone=true,TTLAfterFinished=true
         healthz-bind-address: 0.0.0.0
         node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/roadmap/issues/2385

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Not yet.
