### PR TITLE
Fix feature gates typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Fix typo in control plane feature gates configuration.
+
 ## [0.32.0] - 2023-04-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved the core components feature flags to their configuration, as the `featureGates` field is for `kubeadm` feature flags.
+
 ### Fix
 
 - Fix typo in control plane feature gates configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved the core components feature flags to their configuration, as the `featureGates` field is for `kubeadm` feature flags.
 
-### Fix
+### Removed
 
-- Fix typo in control plane feature gates configuration.
+- Remove `TTLAfterFinished` because it defaults to true.
 
 ## [0.32.0] - 2023-04-26
 
 ### Changed
 
-- Enable `CronJobTimeZone` feature gate in the kubelet.
+- Enable `CronJobTimeZone` feature gate in the kubelet.  
 - Set kubernetes `1.24.10` as the default version.
 - Switch from the in-tree cloud-controller-manager to the external one. This requires version `v0.26.0` of `default-apps-aws`.
 

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -98,6 +98,7 @@ spec:
           api-audiences: "sts.amazonaws.com{{ if hasPrefix "cn-" (include "aws-region" .) }}.cn{{ end }}"
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodSecurityPolicy
+          feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
           kubelet-preferred-address-types: InternalIP
           profiling: "false"
           runtime-config: api/all=true,scheduling.k8s.io/v1alpha1=true
@@ -127,6 +128,7 @@ spec:
           cloud-provider: external
           allocate-node-cidrs: "true"
           cluster-cidr: {{ .Values.connectivity.network.podCidr }}
+          feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
@@ -134,11 +136,9 @@ spec:
       etcd:
         local:
           extraArgs:
+            feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
             listen-metrics-urls: "http://0.0.0.0:2381"
             quota-backend-bytes: "8589934592"
-      featureGates:
-        CronJobTimeZone: true
-        TTLAfterFinished: true
       networking:
         serviceSubnet: {{ .Values.connectivity.network.serviceCidr }}
     files:

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -98,7 +98,7 @@ spec:
           api-audiences: "sts.amazonaws.com{{ if hasPrefix "cn-" (include "aws-region" .) }}.cn{{ end }}"
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodSecurityPolicy
-          feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
+          feature-gates: CronJobTimeZone=true
           kubelet-preferred-address-types: InternalIP
           profiling: "false"
           runtime-config: api/all=true,scheduling.k8s.io/v1alpha1=true
@@ -128,15 +128,15 @@ spec:
           cloud-provider: external
           allocate-node-cidrs: "true"
           cluster-cidr: {{ .Values.connectivity.network.podCidr }}
-          feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
+          feature-gates: CronJobTimeZone=true
       scheduler:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: 0.0.0.0
+          feature-gates: CronJobTimeZone=true
       etcd:
         local:
           extraArgs:
-            feature-gates: TTLAfterFinished=true,CronJobTimeZone=true
             listen-metrics-urls: "http://0.0.0.0:2381"
             quota-backend-bytes: "8589934592"
       networking:

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -136,7 +136,7 @@ spec:
           extraArgs:
             listen-metrics-urls: "http://0.0.0.0:2381"
             quota-backend-bytes: "8589934592"
-      feature-gates:
+      featureGates:
         CronJobTimeZone: true
         TTLAfterFinished: true
       networking:

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -84,7 +84,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
-        feature-gates: CronJobTimeZone=true,TTLAfterFinished=true
+        feature-gates: CronJobTimeZone=true
         healthz-bind-address: 0.0.0.0
         node-ip: '{{ `{{ ds.meta_data.local_ipv4 }}` }}'
         node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ $name }},{{- join "," $value.customNodeLabels }}


### PR DESCRIPTION
### What this PR does / why we need it
The name of [the field is `featureGates`](https://github.com/kubernetes-sigs/cluster-api/blob/main/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go#L143) instead of `feature-gates`.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
