### PR TITLE
Drop architect templating from Chart.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `app.kubernetes.io/version` from common labels. They are part of hashes, but we don't want to always roll nodes just because we are deploying a new version. 
+- Remove `architect` templating from `Chart.yaml` file.
 
 ### Added
 

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -1,9 +1,12 @@
 apiVersion: v2
 name: cluster-aws
+home: https://github.com/giantswarm/cluster-aws
+sources:
+  - https://github.com/giantswarm/cluster-aws
 description: A helm chart for creating Cluster API clusters with the AWS infrastructure provider (CAPA).
 icon: https://s.giantswarm.io/app-icons/aws/1/dark.svg
 type: application
-version: [[ .Version ]]
+version: 0.32.1
 annotations:
   application.giantswarm.io/team: "hydra"
   application.giantswarm.io/app-type: "cluster"


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/roadmap/issues/2453

We use `abs` to build our helm chart in CircleCI. But we kept the `[[ .Version ]]` templating string in our `Chart.yaml` file, that was supposed to be replaced by `architect`.

With the changes in this PR we keep the version in the `Chart.yaml` file, which is keep up to date by [the release automation in place](https://github.com/giantswarm/cluster-aws/blob/master/.github/workflows/zz_generated.create_release_pr.yaml#L161-L201). When building the Helm chart and pushing it to our catalog, `abs` will replace the `version` field from the `Chart.yaml` file with the git sha/git tag, [because that's how it's configured](https://github.com/giantswarm/cluster-aws/blob/master/.abs/main.yaml#L1).

### Checklist

- [X] Update changelog in CHANGELOG.md.
