### PR TITLE
Add service priority property and label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `app.kubernetes.io/version` from common labels. They are part of hashes, but we don't want to always roll nodes just because we are deploying a new version.
 - Remove `architect` templating from `Chart.yaml` file.
 - Set `r6i.xlarge` as the new default AWS instance type for the control plane and node pools.
+- Added value `.metadata.servicePriority` to the schema to set the cluster's relative priority.
 
 ### Added
 

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -15,6 +15,9 @@ metadata:
     {{- end }}
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
+    {{- if .Values.metadata.servicePriority }}
+    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority }}
+    {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
   name: {{ include "resource.default.name" $ }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -683,6 +683,18 @@
                 "organization": {
                     "type": "string",
                     "title": "Organization"
+                },
+                "servicePriority": {
+                    "type": "string",
+                    "title": "Service priority",
+                    "description": "The relative importance of this cluster.",
+                    "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                    "enum": [
+                        "highest",
+                        "medium",
+                        "lowest"
+                    ],
+                    "default": "highest"
                 }
             }
         },

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -69,7 +69,8 @@ kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io
   tag: 1.23.5
-metadata: {}
+metadata:
+  servicePriority: highest
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "075585003325"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13342

This PR adds the capability to configure the cluster's service priority as defined in [this RFC](https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority).

The implementation is copied from cluster-azure.