### PR TITLE
Update cluster-shared dependency to 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove control plane replicas value `controlPlane.replicas`. Now it's hardcoded to 3 nodes.
 - Set `r6i.xlarge` as the new default AWS instance type for the control plane and node pools.
 - Added value `.metadata.servicePriority` to the schema to set the cluster's relative priority.
+- Updated `cluster-shared` chart dependency to `0.6.5`
 
 ### Added
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.6.4
-digest: sha256:8df8c11fb4553caa08324abbbd9d119422049e26de209c747c6a0f91b1343783
-generated: "2022-11-08T09:38:49.67927Z"
+  version: 0.6.5
+digest: sha256:954be7fbf2365fca44d3a84aaf0e5272d9022f3146d4d9ead38f8e1e275a92f8
+generated: "2023-06-01T15:50:02.226889133+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,5 +16,5 @@ restrictions:
     - capa
 dependencies:
 - name: cluster-shared
-  version: "0.6.4"
+  version: "0.6.5"
   repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
### What this PR does / why we need it

Update `cluster-shared` dependency to 0.6.5

- Adds `seccomp` annotation to `restricted` psp

Towards https://github.com/giantswarm/giantswarm/issues/27124

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
