### PR TITLE
Disallow additionalProperties on nodePools (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use CAPBK to provision bastion node with Flatcar AMI.
 - Update CAPA CRs API version from `v1beta1` to `v1beta2`.
+- Values schema: disallow additional properties on the `.nodePools` object. This is a **breaking change** where node pool names are in use that do not match the pattern `^[a-z0-9]{5,10}$`.
 
 ## [0.33.0] - 2023-06-07
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -702,6 +702,7 @@
             "type": "object",
             "title": "Node pools",
             "description": "Node pools of the cluster. If not specified, this defaults to the value of `internal.nodePools`.",
+            "additionalProperties": false,
             "patternProperties": {
                 "^[a-z0-9]{5,10}$": {
                     "$ref": "#/$defs/machinePool"


### PR DESCRIPTION
### What this PR does / why we need it

Closes https://github.com/giantswarm/roadmap/issues/2581 . See issue for details.

**NOTE**: This is a **breaking change** where node pool names are in use that do not match the pattern `^[a-z0-9]{5,10}$`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
