### PR TITLE
Set value for terminated pod gc threshold to be consistent with vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+
 ## [0.35.1] - 2023-06-29
 
 ## Fixed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -143,6 +143,7 @@ spec:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: 0.0.0.0
           cloud-provider: external
+          terminated-pod-gc-threshold: "125"
           allocate-node-cidrs: "true"
           cluster-cidr: {{ .Values.connectivity.network.pods.cidrBlocks | first }}
           feature-gates: CronJobTimeZone=true


### PR DESCRIPTION
Towards https://github.com/giantswarm/klingel/issues/91

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
