### PR TITLE
Remove finalizers from 'HelmCharts' when removing this app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove finalizers from `HelmCharts` when removing this app to avoid leaving leftovers in the management cluster.
+
 ## [0.35.1] - 2023-06-29
 
 ## Fixed

--- a/helm/cluster-aws/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-aws/templates/cleanup-helmreleases-hook-job.yaml
@@ -108,6 +108,7 @@ spec:
             - "-xc"
             - |
               for r in $(kubectl get helmrelease -n {{ $.Release.Namespace }} -l "giantswarm.io/cluster={{ include "resource.default.name" . }}" -o name) ; do
+                  kubectl patch -n {{ $.Release.Namespace }} `kubectl get helmrelease -n {{ $.Release.Namespace }} "${r}" -o jsonpath='{.status.helmChart}'` --type=merge -p '{"metadata": {"finalizers": []}}'
                   kubectl patch -n {{ $.Release.Namespace }} "${r}" --type=merge -p '{"metadata": {"finalizers": []}}'
               done
           securityContext:


### PR DESCRIPTION
### What this PR does / why we need it
When removing clusters, sometimes `HelmCharts` become a leftover because flux doesn't have time to remove them in time before rbac-operator removes RBAC rules needed to have permissions to remove the finalizer from `HelmCharts`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
/run cluster-test-suites
