### PR TITLE
Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and conditionally the proxy host, covering only the `giantswarm` and `kube-system` namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and conditionally the proxy host, covering only the `giantswarm` and `kube-system` namespaces
+
 ## [0.36.1] - 2023-07-11
 
 ### Fixed
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
 
 ## [0.35.1] - 2023-06-29
 
@@ -90,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Enable `CronJobTimeZone` feature gate in the kubelet.  
+- Enable `CronJobTimeZone` feature gate in the kubelet.
 - Set kubernetes `1.24.10` as the default version.
 - Switch from the in-tree cloud-controller-manager to the external one. This requires version `v0.26.0` of `default-apps-aws`.
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -44,6 +44,7 @@ Properties within the `.connectivity` top-level object
 | `connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
+| `connectivity.createCiliumNetworkPolicies` | **Create CiliumNetworkPolicy manifests for DNS and proxy access in critical namespaces** - For the namespaces `giantswarm` and `kube-system`, this creates a network policy allowing DNS access. If `proxy.enabled` is true, egress to the proxy is allowed as well, but for now this only supports an FQDN, not an IP address, inside the `httpProxy`/`httpsProxy` URLs.|**Type:** `boolean`<br/>**Default:** `false`|
 | `connectivity.dns` | **DNS**|**Type:** `object`<br/>|
 | `connectivity.dns.additionalVpc` | **Additional VPCs** - If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.|**Type:** `array`<br/>|
 | `connectivity.dns.additionalVpc[*]` | **VPC identifier**|**Type:** `string`<br/>**Example:** `"vpc-x2aeasd1d"`<br/>**Value pattern:** `^vpc-[0-0a-zA-Z]+$`<br/>|
@@ -116,7 +117,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | :----------- | :-------------- | :--------------- |
 | `internal.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.10"`|
-| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","minSize":3}}`|
+| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","maxSize":3,"minSize":3}}`|
 | `internal.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|

--- a/helm/cluster-aws/ci/test-mc-proxy.yaml
+++ b/helm/cluster-aws/ci/test-mc-proxy.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: test-mc-proxy
+  organization: test
+  servicePriority: lowest
+baseDomain: example.com
+connectivity:
+  createCiliumNetworkPolicies: true
+  proxy:
+    enabled: true
+    httpProxy: http://proxy.mcproxy.example.com:4000
+    httpsProxy: http://proxy.mcproxy.example.com:4000

--- a/helm/cluster-aws/templates/ciliumnetworkpolicies.yaml
+++ b/helm/cluster-aws/templates/ciliumnetworkpolicies.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.connectivity.createCiliumNetworkPolicies }}
+{{- range $_, $ns := (list "giantswarm" "kube-system") }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-dns
+  namespace: {{ $ns }}
+spec:
+  endpointSelector: {} # any
+
+  egress:
+    - toServices:
+        - k8sServiceSelector:
+            namespace: kube-system
+            selector:
+              matchLabels:
+                k8s-app: coredns
+
+      toPorts:
+        - ports:
+            - port: "1053" # must be the target port, not service port
+              protocol: ANY
+{{- if $.Values.connectivity.proxy.enabled }}
+
+          # Required so Cilium registers DNS responses in the FQDN cache
+          # as needed for the proxy access rule below which uses `toFQDNs`
+          # (https://docs.cilium.io/en/stable/security/policy/language/#example)
+          rules:
+            dns:
+              - matchPattern: "*"
+{{ end -}}
+
+{{- if $.Values.connectivity.proxy.enabled }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ include "resource.default.name" $ }}-proxy
+  namespace: {{ $ns }}
+spec:
+  endpointSelector: {} # any
+
+  egress:
+    - toFQDNs:
+        # The whole cluster should be allowed to reach the proxy. This currently does not limit the port range.
+        {{- range $_, $proxyUrl := ((list $.Values.connectivity.proxy.httpProxy $.Values.connectivity.proxy.httpsProxy) | uniq) }}
+        {{- if $proxyUrl }}
+        - matchName: {{ regexReplaceAll "^https?://|:[0-9]+.*" $proxyUrl "" | quote }}
+        {{- end }}
+        {{- end }}
+{{ end -}}
+
+{{ end -}}
+{{ end -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -205,6 +205,12 @@
                         ]
                     }
                 },
+                "createCiliumNetworkPolicies": {
+                    "type": "boolean",
+                    "title": "Create CiliumNetworkPolicy manifests for DNS and proxy access in critical namespaces",
+                    "description": "For the namespaces `giantswarm` and `kube-system`, this creates a network policy allowing DNS access. If `proxy.enabled` is true, egress to the proxy is allowed as well, but for now this only supports an FQDN, not an IP address, inside the `httpProxy`/`httpsProxy` URLs.",
+                    "default": false
+                },
                 "dns": {
                     "type": "object",
                     "title": "DNS",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -10,6 +10,7 @@ connectivity:
     docker.io:
       - endpoint: registry-1.docker.io
       - endpoint: giantswarm.azurecr.io
+  createCiliumNetworkPolicies: false
   dns:
     mode: public
   network:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/27266

For CAPA proxy-private MCs (such as `goat`), we need to allow critical applications such as our operators to reach the proxy. The proxy is defined by hostname, e.g. `proxy.goatproxy.gaws.gigantic.internal` or `internal-foobar.eu-north-1.elb.amazonaws.com`. Cilium offers L7-level allow rules: `toFQDNs`. To make that work, Cilium needs to capture DNS responses to cache the mapping from hostname to IPs, of which it will manage L3 allow-these-IPs rules. Since we don't want to copy-paste a proxy-related network policy solution into every operator app, it makes sense to put it into the cluster app (here: `cluster-aws`), since we deploy Cilium and proxy settings from here.

As Cilium's [default enforcement mode](https://docs.cilium.io/en/latest/security/policy/intro/) turns all pods into default-deny-(egress/ingress) once a pod is selected by any policy, even a cluster-wide policy, we reduce the scope of the new network policies down to critical namespaces. Together with https://github.com/giantswarm/giantswarm/issues/23014, all operators should work fine.

I tested on `golem` (only the DNS policy will be deployed) and on `goat` (also the allow-egress-to-proxy policy gets deployed). Enabling `connectivity.createCiliumNetworkPolicies=true` (feature of _this_ PR, to be enabled on all MCs by default) will be coordinated together with CAPA network policies (https://github.com/giantswarm/cluster-api-provider-aws-app/pull/173) and ultimately the introduction of default-deny-all policies for egress _and_ ingress.

Request for reviewers: is the documentation enough? Should we explain more about its use, which is meant for MCs?

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/test create
/test upgrade
/run cluster-test-suites
