### PR TITLE
Add always-required values to `noProxy` list for aws-cloud-controller-manager-app and aws-ebs-csi-driver-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add always-required values to `noProxy` list for aws-cloud-controller-manager-app and aws-ebs-csi-driver-app (only relevant for private clusters with proxy)
+
 ## [0.37.0] - 2023-07-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add always-required values to `noProxy` list for aws-cloud-controller-manager-app and aws-ebs-csi-driver-app (only relevant for private clusters with proxy)
+- Forbid additional properties under `connectivity.proxy` to avoid typos
 
 ## [0.37.0] - 2023-07-19
 
@@ -41,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage )
 
 ## [0.35.1] - 2023-06-29
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -116,7 +116,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | :----------- | :-------------- | :--------------- |
 | `internal.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.10"`|
-| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","minSize":3}}`|
+| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","maxSize":3,"minSize":3}}`|
 | `internal.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|

--- a/helm/cluster-aws/files/http-proxy.conf
+++ b/helm/cluster-aws/files/http-proxy.conf
@@ -1,7 +1,7 @@
 [Service]
 Environment="HTTP_PROXY={{ .Values.connectivity.proxy.httpProxy }}"
 Environment="HTTPS_PROXY={{ .Values.connectivity.proxy.httpsProxy }}"
-Environment="NO_PROXY=elb.amazonaws.com,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ $.Values.connectivity.proxy.noProxy }}"
+Environment="NO_PROXY={{ include "noProxyList" $ }}"
 Environment="http_proxy={{ .Values.connectivity.proxy.httpProxy }}"
 Environment="https_proxy={{ .Values.connectivity.proxy.httpsProxy }}"
-Environment="no_proxy=elb.amazonaws.com,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ $.Values.connectivity.proxy.noProxy }}"
+Environment="no_proxy={{ include "noProxyList" $ }}"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -76,6 +76,9 @@ room for such suffix.
   content: {{ $.Files.Get "files/etc/ssh/sshd_config_bastion" | b64enc }}
 {{- end -}}
 
+{{- define "noProxyList" -}}
+127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}
+{{- end -}}
 {{- define "proxyFiles" -}}
 - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
   permissions: "0644"
@@ -89,10 +92,10 @@ room for such suffix.
 {{- define "proxyCommand" -}}
 - export HTTP_PROXY={{ $.Values.connectivity.proxy.httpProxy }}
 - export HTTPS_PROXY={{ $.Values.connectivity.proxy.httpsProxy }}
-- export NO_PROXY=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}
+- export NO_PROXY="{{ include "noProxyList" $ }}"
 - export http_proxy={{ $.Values.connectivity.proxy.httpProxy }}
 - export https_proxy={{ $.Values.connectivity.proxy.httpsProxy }}
-- export no_proxy=127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}
+- export no_proxy="{{ include "noProxyList" $ }}"
 {{- end -}}
 
 {{- define "registryFiles" -}}
@@ -163,7 +166,7 @@ room for such suffix.
 - name: var-lib-etcd.mount
   enabled: true
   contents: |
-    [Unit] 
+    [Unit]
     Description=etcd volume
     DefaultDependencies=no
     [Mount]

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.connectivity.proxy }}
   values:
     proxy:
-      noProxy: {{ .Values.connectivity.proxy.noProxy }}
-      http: {{ .Values.connectivity.proxy.httpProxy }}
-      https: {{ .Values.connectivity.proxy.httpsProxy }}
+      noProxy: "127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}"
+      http: {{ .Values.connectivity.proxy.httpProxy | quote }}
+      https: {{ .Values.connectivity.proxy.httpsProxy | quote }}
   {{ end }}

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -32,10 +32,10 @@ spec:
   install:
     remediation:
       retries: 30
-  {{- if .Values.connectivity.proxy }}
+  {{- if .Values.connectivity.proxy.enabled }}
   values:
     proxy:
-      noProxy: "127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}"
+      noProxy: "{{ include "noProxyList" $ }}"
       http: {{ .Values.connectivity.proxy.httpProxy | quote }}
       https: {{ .Values.connectivity.proxy.httpsProxy | quote }}
   {{ end }}

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if .Values.connectivity.proxy }}
   values:
     proxy:
-      noProxy: {{ .Values.connectivity.proxy.noProxy }}
-      http: {{ .Values.connectivity.proxy.httpProxy }}
-      https: {{ .Values.connectivity.proxy.httpsProxy }}
+      noProxy: "127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}"
+      http: {{ .Values.connectivity.proxy.httpProxy | quote }}
+      https: {{ .Values.connectivity.proxy.httpsProxy | quote }}
   {{ end }}

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -32,10 +32,10 @@ spec:
   install:
     remediation:
       retries: 30
-  {{- if .Values.connectivity.proxy }}
+  {{- if .Values.connectivity.proxy.enabled }}
   values:
     proxy:
-      noProxy: "127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.connectivity.network.vpcCidr }},{{ join "," $.Values.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.connectivity.proxy.noProxy }}"
+      noProxy: "{{ include "noProxyList" $ }}"
       http: {{ .Values.connectivity.proxy.httpProxy | quote }}
       https: {{ .Values.connectivity.proxy.httpsProxy | quote }}
   {{ end }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -309,6 +309,7 @@
                     "type": "object",
                     "title": "Proxy",
                     "description": "Whether/how outgoing traffic is routed through proxy servers.",
+                    "additionalProperties": false,
                     "properties": {
                         "enabled": {
                             "type": "boolean",


### PR DESCRIPTION
### What this PR does / why we need it

This used to work without users having to provide these values explicitly. Even if the `noProxy` config is empty, the defaults should lead to a working cluster. The PR fixes this again after `HelmRelease`s were introduced.

Somewhat related to testing of https://github.com/giantswarm/giantswarm/issues/27266

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test upgrade

/run cluster-test-suites
