### PR TITLE
Tolerate CAPI taints on uninitialized nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tolerate CAPI taints on uninitialized nodes when scheduling cilium relay and ui.
+
 ## [0.37.0] - 2023-07-19
 
 ### Changed

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -41,6 +41,15 @@ spec:
     hubble:
       relay:
         enabled: true
+        tolerations:
+          - key: "node.cluster.x-k8s.io/uninitialized"
+            operator: "Exists"
+            effect: "NoSchedule"
+      ui:
+        tolerations:
+          - key: "node.cluster.x-k8s.io/uninitialized"
+            operator: "Exists"
+            effect: "NoSchedule"
     defaultPolicies:
       enabled: true
       tolerations:


### PR DESCRIPTION
### What this PR does / why we need it

`cilium` helm release takes very long to become ready because cilium ui and cilium relay pods can't be scheduled on CAPI uninitialized nodes. I think it's safe to add these tolerations, because CAPI initialization of nodes is just syncing labels.

### Checklist

- [X] Update changelog in CHANGELOG.md.

