### PR TITLE
Remove cilium dependencies while installing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove dependency between `cilium` and CPI so that `cilium` is installed as soon as possible. 
+
 ## [0.38.0] - 2023-08-24
 
 ### Fixed

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -23,9 +23,6 @@ spec:
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig
-  dependsOn:
-    - name: {{ include "resource.default.name" $ }}-cloud-provider-aws
-      namespace: {{ $.Release.Namespace }}
   interval: 5m
   install:
     remediation:


### PR DESCRIPTION
### What this PR does / why we need it
There is no reason to wait for the CPI before installing cilium.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
