### PR TITLE
Add schema to service account issuer URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `scheme` to service-account-issuer URI.
+
 ## [0.38.3] - 2023-08-29
 
 ### Fixed

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -95,7 +95,7 @@ spec:
           - 127.0.0.1
         extraArgs:
           cloud-provider: external
-          service-account-issuer: "irsa.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
+          service-account-issuer: "https://irsa.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
           {{- if .Values.controlPlane.oidc.issuerUrl }}
           {{- with .Values.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}


### PR DESCRIPTION
### What this PR does / why we need it



The `service-account-issuer` arg requires a URI, which should include the `schema`.

> Identifier  of the service account token issuer. The issuer will assert this  identifier in "iss" claim of issued tokens. This value is a string or  URI. If this option is not a valid URI per the OpenID Discovery 1.0  spec, the ServiceAccountIssuerDiscovery feature will remain disabled,  even if the feature gate is set to true. It is highly recommended that  this value comply with the OpenID spec:  https://openid.net/specs/openid-connect-discovery-1_0.html. In practice,  this means that service-account-issuer must be an https URL. It is also  highly recommended that this URL be capable of serving OpenID discovery  documents at {service-account-issuer}/.well-known/openid-configuration.  When this flag is specified multiple times, the first is used to  generate tokens and all are used to determine which issuers are  accepted.

More details https://gigantic.slack.com/archives/C02GLN41UP2/p1693239516555659

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
