### PR TITLE
Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and conditionally the proxy host, covering only the `giantswarm` and `kube-system` namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and conditionally the proxy host (via [`cilium-app`](https://github.com/giantswarm/cilium-app))
+
 ## [0.38.4] - 2023-08-30
 
 ### Fixed

--- a/helm/cluster-aws/ci/test-mc-proxy.yaml
+++ b/helm/cluster-aws/ci/test-mc-proxy.yaml
@@ -1,0 +1,10 @@
+metadata:
+  name: test-mc-proxy
+  organization: test
+  servicePriority: lowest
+baseDomain: example.com
+connectivity:
+  proxy:
+    enabled: true
+    httpProxy: http://proxy.mcproxy.example.com:4000
+    httpsProxy: http://proxy.mcproxy.example.com:4000

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.10.0
+      version: 0.12.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -59,3 +59,10 @@ spec:
           operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
+    extraPolicies:
+      allowEgressToCoreDNS:
+        enabled: true
+      allowEgressToProxy:
+        enabled: {{ $.Values.connectivity.proxy.enabled }}
+        httpProxy: {{ $.Values.connectivity.proxy.httpProxy | quote }}
+        httpsProxy: {{ $.Values.connectivity.proxy.httpsProxy | quote }}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/27266. Replaces the closed PR https://github.com/giantswarm/cluster-aws/pull/341 which was wrong because network policies must be installed in the MC/WC, respectively, and therefore shouldn't be a direct part of the Helm template, but now went into `cilium-app`.

Proxy-private clusters require connectivity to the proxy. With a deny-all network policy, access to the proxy needs to be explicitly allowed. With this change, we 1) allow reaching CoreDNS to resolve the proxy (e.g. `proxy.goatproxy.gaws.gigantic.internal`) and 2) allow reaching the proxy domain via Cilium Layer 7 rules. Note how 1) is required because Cilium inspects DNS requests in order to get a domain-to-IPs mapping that is required to evaluate Layer 7 rules (`toFQDNs` in network policy, see cilium-app https://github.com/giantswarm/cilium-app/pull/83/files). After some discussions, this change is scoped for the `giantswarm` and `kube-system` namespaces only so that other applications on the MC/WC are not affected (note how Cilium's [default enforcement mode](https://docs.cilium.io/en/latest/security/policy/intro/) uses deny-all if any rule matches a pod, such as the ones we're adding _here_).

This includes cilium-app v0.10.0..v0.12.0 changes such as a newer upstream version. It worked fine for me, so https://github.com/giantswarm/cluster-aws/pull/369 is probably not needed anymore (@njuettner).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
