### PR TITLE
Add old issuer URL as second `--service-account-issuer` parameter for API server to avoid a breaking change in v0.38.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+⚠️ When upgrading, please use v0.41.0 (_this release_) or newer. See our note on the breaking change in v0.38.4.
+
+### Fixed
+
+- Accept old service account issuer URI without `https://` prefix as well. This fixes the breaking change introduced in v0.38.4. Existing service account tokens, and the operators/applications using them, will keep working even before the tokens get rotated with the new service account issuer URI. When upgrading, it is recommended to skip earlier releases and immediately jump from v0.38.3 (or older) to _this one_.
+
 ## [0.40.0] - 2023-09-18
+
+⚠️ When upgrading, please use v0.41.0 or newer. See our note on the breaking change in v0.38.4.
 
 ### Added
 
@@ -15,11 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0] - 2023-09-12
 
+⚠️ When upgrading, please use v0.41.0 or newer. See our note on the breaking change in v0.38.4.
+
 ### Added
 
 - Support creating `CiliumNetworkPolicy` manifests that allow egress requests to DNS and conditionally the proxy host (via [`cilium-app`](https://github.com/giantswarm/cilium-app))
 
 ## [0.38.5] - 2023-09-12
+
+⚠️ When upgrading, please use v0.41.0 or newer. See our note on the breaking change in v0.38.4.
 
 ### Changed
 
@@ -27,9 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.38.4] - 2023-08-30
 
-### Fixed
+⚠️ We advise not to upgrade from v0.38.3 (or older) to v0.38.4. Please use v0.41.0 or newer which ensures that both the old and new service account issuer URIs are allowed (difference is only the `https://` prefix, which is a breaking change), avoiding that operators lose access to the Kubernetes API which could render the cluster unhealthy.
 
-- Add `scheme` to service-account-issuer URI.
+### Changed
+
+- Add `https://` scheme prefix to service-account-issuer URI
 
 ## [0.38.3] - 2023-08-29
 

--- a/helm/cluster-aws/files/opt/control-plane-config.sh
+++ b/helm/cluster-aws/files/opt/control-plane-config.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+error() {
+	>&2 echo "ERROR: " "${@}"
+	exit 1
+}
+
+[ -e /etc/kubernetes/manifests/kube-apiserver.yaml ] || error "API server static pod manifest missing"
+[ -s /etc/kubernetes/manifests/kube-apiserver.yaml ] || error "API server static pod manifest empty"
+
+# Fix for breaking change when upgrading to v0.38.4+: `--service-account-issuer` value changes to have
+# prefix `https://`, and that means existing tokens issued with the old URI are not allowed access
+# to the Kubernetes API anymore, breaking operators and other software. Currently, we cannot provide both
+# the old and new allowed issuer URL in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs`
+# because it's a map (https://github.com/kubernetes/kubeadm/issues/1601). Therefore, we overwrite the static pod
+# manifest directly. Restarting the kubelet process ensures updating the pod.
+# The new issuer URL (`https://[...]`) is the first `--service-account-issuer` argument, while the old
+# one is the second so that it's still allowed but not used to issue new JWT tokens.
+#
+# This can be removed once all management/workload clusters based on cluster-aws are on a newer version. The following
+# script is idempotent.
+if [ "$(grep -c -- '--service-account-issuer' /etc/kubernetes/manifests/kube-apiserver.yaml)" = 1 ]; then
+	awk '
+		/--service-account-issuer/ {
+			new=$0
+			gsub(/issuer=(https:\/\/)?/, "issuer=https://", new)
+
+			old=$0
+			gsub(/issuer=(https:\/\/)?/, "issuer=", old)
+
+			print new
+			print old
+			next
+		}
+		{
+			print
+		}
+	' /etc/kubernetes/manifests/kube-apiserver.yaml > /tmp/kube-apiserver.yaml.patched
+	mv -v /tmp/kube-apiserver.yaml.patched /etc/kubernetes/manifests/kube-apiserver.yaml
+
+	echo "API server manifest patched with service account issuer URLs"
+
+	systemctl restart kubelet
+else
+	echo "API server manifest already has two \`--service-account-issuer\` entries, skipping fix"
+fi

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -160,7 +160,7 @@ spec:
       networking:
         serviceSubnet: {{ join "," .Values.connectivity.network.services.cidrBlocks }}
     files:
-    {{- include "oidcFiles" . | nindent 4 }}
+    {{- include "controlPlaneFiles" . | nindent 4 }}
     {{- include "sshFiles" . | nindent 4 }}
     {{- include "kubeletConfigFiles" . | nindent 4 }}
     {{- include "nodeConfigFiles" . | nindent 4 }}
@@ -215,6 +215,7 @@ spec:
     {{- if .Values.connectivity.proxy.enabled }}{{- include "proxyCommand" $ | nindent 4 }}{{- end }}
     postKubeadmCommands:
     {{- include "kubeletConfigPostKubeadmCommands" . | nindent 4 }}
+    {{- include "controlPlanePostKubeadmCommands" . | nindent 4 }}
     users:
     {{- include "sshUsers" . | nindent 4 }}
   replicas: 3

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -45,13 +45,17 @@ room for such suffix.
 {{- .Values.metadata.name | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
-{{- define "oidcFiles" -}}
+{{- define "controlPlaneFiles" -}}
 {{- if .Values.controlPlane.oidc.caPem }}
 - path: /etc/ssl/certs/oidc.pem
   permissions: "0600"
   encoding: base64
   content: {{ tpl ($.Files.Get "files/etc/ssl/certs/oidc.pem") . | b64enc }}
 {{- end }}
+- path: /opt/control-plane-config.sh
+  permissions: "0700"
+  encoding: base64
+  content: {{ $.Files.Get "files/opt/control-plane-config.sh" | b64enc }}
 {{- end -}}
 
 {{- define "sshFiles" -}}
@@ -203,6 +207,10 @@ room for such suffix.
 
 {{- define "sshPreKubeadmCommands" -}}
 - systemctl restart sshd
+{{- end -}}
+
+{{- define "controlPlanePostKubeadmCommands" -}}
+- /opt/control-plane-config.sh
 {{- end -}}
 
 {{- define "kubeletConfigPostKubeadmCommands" -}}


### PR DESCRIPTION
### What this PR does / why we need it

Fixes https://github.com/giantswarm/giantswarm/issues/28165

In short: use two arguments `--service-account-issuer=https://irsa.[...] --service-account-issuer=irsa.[...]` so old and new service account tokens are allowed during upgrade and until the old tokens expire and get rotated.

I tested this by upgrading from v0.38.3 to `v0.40.0 + my changes`, and the Kubernetes API was only unavailable shortly during rollout of nodes. For comparison, I tried the broken upgrade v0.38.3..v0.38.4 and it gave me 100% `error: You must be logged in to the server (Unauthorized)` errors after the rollout because all existing tokens still had the old (and not accepted) issuer URI without the `https://` prefix.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
