### PR TITLE
Remove installation of Cilium policies that allow certain cluster traffic unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove installation of Cilium policies that allow certain cluster traffic unconditionally (`defaultPolicies.enabled` in `cilium-app`). This is no longer necessary as all operators have been adapted with own network policies.
+
 ## [0.42.0] - 2023-09-21
 
 ### Removed

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.12.0
+      version: 0.13.0
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default
@@ -48,7 +48,10 @@ spec:
             operator: "Exists"
             effect: "NoSchedule"
     defaultPolicies:
-      enabled: true
+      # Operators need to define their own network policies. Disable/undeploy the overarching allow rules.
+      enabled: false
+      remove: true
+
       tolerations:
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/27266

This is hopefully the last generic allow rule. All operators have their own policies and don't seem to need this generic one anymore. See https://github.com/giantswarm/cilium-app/pull/93 and the [default policy manifests](https://github.com/giantswarm/cilium-app/tree/main/helm/cilium/files/policies) which we're not using anymore with this change.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
