### PR TITLE
Align clean up with other providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align job that cleans `HelmReleases` and `HelmCharts` with other providers.
+
 ### Removed
 
 - Remove installation of Cilium policies that allow certain cluster traffic unconditionally (`defaultPolicies.enabled` in `cilium-app`). This is no longer necessary as all operators have been adapted with own network policies.

--- a/helm/cluster-aws/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-aws/templates/cleanup-helmreleases-hook-job.yaml
@@ -44,22 +44,10 @@ metadata:
 rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
-    verbs: ["get", "list"]
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: ["helmreleases"]
-    resourceNames:
-      - "{{ include "resource.default.name" $ }}-cilium"
-      - "{{ include "resource.default.name" $ }}-cloud-provider-aws"
-      - "{{ include "resource.default.name" $ }}-aws-ebs-csi-driver"
-      - "{{ include "resource.default.name" $ }}-coredns"
-      - "{{ include "resource.default.name" $ }}-vertical-pod-autoscaler-crd"
-    verbs: ["patch"]
+    verbs: ["get", "list", "patch"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["helmcharts"]
-    verbs: ["get", "list"]
-  - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: ["helmcharts"]
-    verbs: ["patch"]
+    verbs: ["get", "list", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -113,8 +101,20 @@ spec:
             - "/bin/sh"
             - "-xc"
             - |
-              kubectl get helmrelease -n {{ $.Release.Namespace }} -o name -l "giantswarm.io/cluster={{ include "resource.default.name" . }}" | xargs -I {} kubectl patch -n {{ $.Release.Namespace }} {} --type=merge -p '{"metadata": {"finalizers": []}}'
-              kubectl get helmchart -n {{ $.Release.Namespace }} -o name | grep "{{ include "resource.default.name" . }}" | xargs -I {} kubectl patch -n {{ $.Release.Namespace }} {} --type=merge -p '{"metadata": {"finalizers": []}}'
+              NAMESPACE="{{ $.Release.Namespace }}"
+              CLUSTER_NAME="{{ include "resource.default.name" . }}"
+
+              for release in $(kubectl get HelmRelease -n ${NAMESPACE} -l "giantswarm.io/cluster=${CLUSTER_NAME}" -o json | jq -r '.items[].metadata.name'); do
+                echo "Patching helmrelease $release to remove finalizers"
+                kubectl patch -n ${NAMESPACE} helmrelease "${release}" --type=merge -p '{"metadata": {"finalizers": []}}'
+              done
+
+              for chart in $(kubectl get HelmChart -n ${NAMESPACE} -o json | jq -r ".items[] | select(.spec.sourceRef.name == \"${CLUSTER_NAME}-default\") | .metadata.name"); do
+                echo "Patching helmchart $chart to remove finalizers"
+                kubectl patch -n ${NAMESPACE} helmchart "${chart}" --type=merge -p '{"metadata": {"finalizers": []}}'
+                echo "Deleting helmchart $chart"
+                kubectl delete -n ${NAMESPACE} helmchart "${chart}" --ignore-not-found=true
+              done
           securityContext:
             readOnlyRootFilesystem: true
           resources:


### PR DESCRIPTION
### What this PR does / why we need it
We have a different way of dealing with `HelmReleases` and `HelmCharts` leftovers on other providers, so I'm taking their approach and applying it here to be aligned.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
