### PR TITLE
Revert to install default Cilium policies again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert to install default Cilium policies again. Some operators' "allow access to API nodes" `NetworkPolicy`s are not effective and Cilium first needs to be upgraded, including a recent upstream fix to the [known issue](https://github.com/cilium/cilium/issues/20550).
+
 ## [0.43.0] - 2023-09-27
 
 ### Removed

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -48,9 +48,7 @@ spec:
             operator: "Exists"
             effect: "NoSchedule"
     defaultPolicies:
-      # Operators need to define their own network policies. Disable/undeploy the overarching allow rules.
-      enabled: false
-      remove: true
+      enabled: true
 
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
### What this PR does / why we need it

See https://github.com/giantswarm/roadmap/issues/2860

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Not really needed since we're basically back to v0.42.0.