### PR TITLE
configure upgrade timeout and upgrade retries for cilium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configure upgrade timeout and upgrade retry count for cilium `HelmRelease`.
+
 ## [0.45.0] - 2023-10-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configure upgrade timeout and upgrade retry count for cilium `HelmRelease`.
+- Configure upgrade timeout and upgrade retry count for cilium and cloud provider `HelmRelease`.
 
 ## [0.45.0] - 2023-10-04
 

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -27,6 +27,10 @@ spec:
   install:
     remediation:
       retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+    timeout: 20m
   # Default values
   # https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml
   values:

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -32,6 +32,10 @@ spec:
   install:
     remediation:
       retries: 30
+  upgrade:
+    remediation:
+      retries: 30
+    timeout: 20m
   {{- if .Values.connectivity.proxy.enabled }}
   values:
     proxy:


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
