### PR TITLE
cluster-autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow cluster-autoscaler handling MachinePools.
+- Add additional tag for cluster autoscaler to MachinePool ASGs.
+
 ## [0.46.1] - 2023-11-01
 
 ### Added

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     machine-pool.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ $name }}
+    cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
   labels:
     giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
     {{- include "labels.common" $ | nindent 4 }}
@@ -41,6 +42,8 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ $name }}
   namespace: {{ $.Release.Namespace }}
 spec:
+  additionalTags:
+    k8s.io/cluster-autoscaler/enabled: "true"
   availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
   subnets:
   - filters:


### PR DESCRIPTION
### What this PR does / why we need it

Issue: https://github.com/giantswarm/roadmap/issues/2927

Prepare CR's to allow managing MachinePools by cluster-autoscaler.

Cluster-autoscaler watches ASG's on two tags 
*  sigs.k8s.io/cluster-api-provider-aws/cluster/CLUSTER_ID <- already an ASG tag
*  k8s.io/cluster-autoscaler/enabled: "true" <- needs to be created by capa-controller because it's not present yet.

I tried to make an overview how it works:
<img width="925" alt="image" src="https://github.com/giantswarm/roadmap/assets/1936982/1f42d708-1c8c-4144-8112-2b760e1537fc">

* capa-controller will only adjust the min and max size for MachinePools in case cluster owner modifies AWSMachinePool CR and updating the status of the current replicas
* cluster-autoscaler will take ownership of scaling in and out according to it's calculation in the workload cluster.

Once released we can manage scaling for MachinePools by cluster-autoscaler.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites