### PR TITLE
Add `global.metadata.preventDeletion` to add the deletion prevention label to cluster resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `global.metadata.preventDeletion` to add the [deletion prevention label](https://docs.giantswarm.io/advanced/deletion-prevention/) to cluster resources
+
 ## [0.47.0] - 2023-11-07
 
 ### Added

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -121,6 +121,15 @@ Properties within the `.controlPlane` top-level object
 | `controlPlane.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>|
 | `controlPlane.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
 
+### Global properties
+Properties within the `.global` top-level object
+Properties that are available to all charts and subcharts.
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.metadata` | **Metadata**|**Type:** `object`<br/>|
+| `global.metadata.preventDeletion` | **Prevent cluster deletion**|**Type:** `boolean`<br/>**Default:** `false`|
+
 ### Internal
 Properties within the `.internal` top-level object
 For Giant Swarm internal use only, not stable, or not supported by UIs.

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -19,6 +19,7 @@ metadata:
     aws.giantswarm.io/vpc-endpoint-mode: "{{ .Values.connectivity.vpcEndpointMode }}"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
+    {{- include "preventDeletionLabel" $ | nindent 4 -}}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -55,6 +55,7 @@ metadata:
   labels:
     cluster.x-k8s.io/role: bastion
     {{- include "labels.common" $ | nindent 4 }}
+    {{- include "preventDeletionLabel" $ | nindent 4 -}}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
   name: {{ include "resource.default.name" $ }}-bastion
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -19,6 +19,7 @@ metadata:
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority }}
     {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
+    {{- include "preventDeletionLabel" $ | nindent 4 -}}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -58,6 +58,12 @@ room for such suffix.
   content: {{ $.Files.Get "files/opt/control-plane-config.sh" | b64enc }}
 {{- end -}}
 
+{{- define "preventDeletionLabel" -}}
+{{- if $.Values.global.metadata.preventDeletion -}}
+giantswarm.io/prevent-deletion: "true"
+{{ end -}}
+{{- end -}}
+
 {{- define "sshFiles" -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
@@ -169,7 +175,7 @@ and is used to join the node to the teleport cluster.
 - path: /etc/teleport.yaml
   permissions: "0644"
   encoding: base64
-  content: {{ tpl ($.Files.Get "files/etc/teleport.yaml") . | b64enc }}  
+  content: {{ tpl ($.Files.Get "files/etc/teleport.yaml") . | b64enc }}
 {{- end -}}
 
 {{- define "diskStorageConfig" -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -688,6 +688,26 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "title": "Global properties",
+            "description": "Properties that are available to all charts and subcharts.",
+            "additionalProperties": false,
+            "properties": {
+                "metadata": {
+                    "type": "object",
+                    "title": "Metadata",
+                    "additionalProperties": true,
+                    "properties": {
+                        "preventDeletion": {
+                            "type": "boolean",
+                            "title": "Prevent cluster deletion",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
         "internal": {
             "type": "object",
             "title": "Internal",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -56,6 +56,9 @@ controlPlane:
     unhealthyUnknownTimeout: 10m0s
   oidc: {}
   rootVolumeSizeGB: 120
+global:
+  metadata:
+    preventDeletion: false
 internal:
   kubernetesVersion: 1.24.14
   migration:


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/28310. Requires https://github.com/giantswarm/schemalint/pull/115.

Add the label to objects that shouldn't be deletable. Since Helm would try to delete the objects not marked with `"helm.sh/resource-policy": keep`, `Cluster` is the most important parent object to protect. Other than those, I added the label to reasonable objects such as `AWSCluster` (which correlates to the AWS infrastructure), but not to objects whose name contains a hash as they need to be deletable by Helm on upgrade (= when the hash in the name probably changes).

I manually tested cluster creation, and also upgrade with manifest changes.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
