### PR TITLE
Avoid duplicates on load balancer ingress rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The value to configure the control plane load balancer ingress rules is filtered to avoid duplicates and to always contain GiantSwarm VPN IPs.
+
 ## [0.47.0] - 2023-11-07
 
 ### Added

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -41,6 +41,7 @@ spec:
       protocol: tcp
       fromPort: 6443
       toPort: 6443
+      # We append the Giant Swarm VPN IPs (internal link: https://github.com/giantswarm/vpn/tree/master/hosts_inventory, https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tc_api_whitelisting/)
       cidrBlocks: {{- toYaml ((concat .Values.controlPlane.loadBalancerIngressAllowCidrBlocks (list "95.179.153.65/32" "185.102.95.187/32")) | uniq) | nindent 6 }}
     {{- end }}
   network:

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -41,12 +41,7 @@ spec:
       protocol: tcp
       fromPort: 6443
       toPort: 6443
-      cidrBlocks:
-      # Giant Swarm VPN IPs (internal link: https://github.com/giantswarm/vpn/tree/master/hosts_inventory, https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tc_api_whitelisting/)
-      - 185.102.95.187/32
-      - 95.179.153.65/32
-
-      {{- toYaml .Values.controlPlane.loadBalancerIngressAllowCidrBlocks | nindent 6 }}
+      cidrBlocks: {{- toYaml ((concat .Values.controlPlane.loadBalancerIngressAllowCidrBlocks (list "95.179.153.65/32" "185.102.95.187/32")) | uniq) | nindent 6 }}
     {{- end }}
   network:
     cni:


### PR DESCRIPTION
### What this PR does / why we need it
Towards https://github.com/giantswarm/giantswarm/issues/28705

In our templates we were always adding GiantSwarm VPN IPs *when custom ingress rules were added*. That worked fine for workload clusters, but we ran into a special corner case for our management clusters. The management cluster only needs the nat gateway IPs to be in the ingress rules, which is automatically added by CAPA, together with the GiantSwarm VPN IPs, which is automatically added by our cluster-aws chart. We don't have any more custom ingress rules to add. Without specifying any custom rule, the GiantSwarm VPN IPs were not added by the chart. But if we added the VPN IPs as custom ingress rules, AWS would complain due to duplicated cidrs on the security group.

So I tweaked the logic a bit. The end result from the user perspective is the same. But now we can specify the VPN IPs as values, and the chart will filter them out because they are duplicates, applying the right ingress rules. This only make sense on the special case of management clusters that should only be accessed by GiantSwarm.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

/run cluster-test-suites
