### PR TITLE
Move Values.metadata to Values.global.metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### **Breaking change**
+
+- Move Helm values property `.Values.metadata` to `.Values.global.metadata`.
+
 ## [0.47.0] - 2023-11-07
 
 ### Added

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,5 +1,6 @@
-metadata:
-  organization: "test"
+global:
+  metadata:
+    organization: "test"
 baseDomain: example.com
 
 connectivity:

--- a/helm/cluster-aws/ci/test-mc-proxy.yaml
+++ b/helm/cluster-aws/ci/test-mc-proxy.yaml
@@ -1,7 +1,8 @@
-metadata:
-  name: test-mc-proxy
-  organization: test
-  servicePriority: lowest
+global:
+  metadata:
+    name: test-mc-proxy
+    organization: test
+    servicePriority: lowest
 baseDomain: example.com
 connectivity:
   proxy:

--- a/helm/cluster-aws/ci/test-spot-instances.yaml
+++ b/helm/cluster-aws/ci/test-spot-instances.yaml
@@ -1,7 +1,8 @@
-metadata:
-  name: test-wc-minimal
-  organization: test
-  servicePriority: lowest
+global:
+  metadata:
+    name: test-wc-minimal
+    organization: test
+    servicePriority: lowest
 baseDomain: example.com
 nodePools:
   pool0:

--- a/helm/cluster-aws/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-aws/ci/test-wc-minimal-values.yaml
@@ -1,5 +1,6 @@
-metadata:
-  name: test-wc-minimal
-  organization: test
-  servicePriority: lowest
+global:
+  metadata:
+    name: test-wc-minimal
+    organization: test
+    servicePriority: lowest
 baseDomain: example.com

--- a/helm/cluster-aws/templates/_cluster.tpl
+++ b/helm/cluster-aws/templates/_cluster.tpl
@@ -3,7 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   annotations:
-    {{- with .Values.metadata.description }}
+    {{- with .Values.global.metadata.description }}
     cluster.giantswarm.io/description: "{{ . }}"
     {{- end }}
     network-topology.giantswarm.io/mode: "{{ .Values.connectivity.topology.mode }}"
@@ -15,8 +15,8 @@ metadata:
     {{- end }}
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    {{- if .Values.metadata.servicePriority }}
-    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority }}
+    {{- if .Values.global.metadata.servicePriority }}
+    giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority }}
     {{- end }}
     {{- include "labels.common" $ | nindent 4 }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -31,7 +31,7 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ required "You must provide an existing organization name in .metadata.organization" .Values.metadata.organization | quote }}
+giantswarm.io/organization: {{ required "You must provide an existing organization name in .global.metadata.organization" .Values.global.metadata.organization | quote }}
 cluster.x-k8s.io/watch-filter: capi
 {{- end -}}
 
@@ -42,7 +42,7 @@ Given that Kubernetes allows 63 characters for resource names, the stem is trunc
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- .Values.metadata.name | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
+{{- .Values.global.metadata.name | default (.Release.Name | replace "." "-" | trunc 47 | trimSuffix "-") -}}
 {{- end -}}
 
 {{- define "controlPlaneFiles" -}}

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-aws-ebs-csi-driver
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cilium
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cloud-provider-aws
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/cluster-aws/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-aws/templates/coredns-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-coredns
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-aws/templates/default-helmrepository.yaml
+++ b/helm/cluster-aws/templates/default-helmrepository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default-test
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-aws/templates/vpa-crd-helmrelease.yaml
+++ b/helm/cluster-aws/templates/vpa-crd-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-vertical-pod-autoscaler-crd
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: "{{ .Values.metadata.description }}"
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -688,6 +688,48 @@
                 }
             }
         },
+        "global": {
+            "type": "object",
+            "title": "Global properties",
+            "description": "Properties that are available to all charts and subcharts.",
+            "required": [
+                "metadata"
+            ],
+            "properties": {
+                "metadata": {
+                    "type": "object",
+                    "title": "Metadata",
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "Cluster description",
+                            "description": "User-friendly description of the cluster's purpose."
+                        },
+                        "name": {
+                            "type": "string",
+                            "title": "Cluster name",
+                            "description": "Unique identifier, cannot be changed after creation."
+                        },
+                        "organization": {
+                            "type": "string",
+                            "title": "Organization"
+                        },
+                        "servicePriority": {
+                            "type": "string",
+                            "title": "Service priority",
+                            "description": "The relative importance of this cluster.",
+                            "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                            "enum": [
+                                "highest",
+                                "medium",
+                                "lowest"
+                            ],
+                            "default": "highest"
+                        }
+                    }
+                }
+            }
+        },
         "internal": {
             "type": "object",
             "title": "Internal",
@@ -875,38 +917,6 @@
             "type": "string",
             "title": "Management cluster",
             "description": "Name of the Cluster API cluster managing this workload cluster."
-        },
-        "metadata": {
-            "type": "object",
-            "title": "Metadata",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "title": "Cluster description",
-                    "description": "User-friendly description of the cluster's purpose."
-                },
-                "name": {
-                    "type": "string",
-                    "title": "Cluster name",
-                    "description": "Unique identifier, cannot be changed after creation."
-                },
-                "organization": {
-                    "type": "string",
-                    "title": "Organization"
-                },
-                "servicePriority": {
-                    "type": "string",
-                    "title": "Service priority",
-                    "description": "The relative importance of this cluster.",
-                    "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
-                    "enum": [
-                        "highest",
-                        "medium",
-                        "lowest"
-                    ],
-                    "default": "highest"
-                }
-            }
         },
         "nodePools": {
             "type": "object",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -56,6 +56,9 @@ controlPlane:
     unhealthyUnknownTimeout: 10m0s
   oidc: {}
   rootVolumeSizeGB: 120
+global:
+  metadata:
+    servicePriority: highest
 internal:
   kubernetesVersion: 1.24.14
   migration:
@@ -79,8 +82,6 @@ kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io
   tag: 1.23.5
-metadata:
-  servicePriority: highest
 providerSpecific:
   awsClusterRoleIdentityName: default
   flatcarAwsAccount: "706635527432"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2954

### What this PR does / why we need it

We have ported all provider-independent Cluster API resources to cluster chart, which was phase 1 of restructuring of cluster- apps, see https://github.com/giantswarm/roadmap/issues/2742 for more details. Now we want to use cluster chart in cluster-aws and remove all provider-independent Cluster API resources from cluster-aws.

In order to do so, first we have to refactor cluster-aws Helm values, so that cluster chart can read provider-independent values it needs. For that, we have to move current top-level properties to be under Values.global.

This pull request moves `Values.metadata` to `Values.global.metadata`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
