### PR TITLE
Fix containerd config flatcar 3602

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix containerd config that was breaking in newer flatcar versions.
+
 ## [0.48.1] - 2023-11-13
 
 ### Fixed

--- a/helm/cluster-aws/files/etc/containerd/config.toml
+++ b/helm/cluster-aws/files/etc/containerd/config.toml
@@ -6,7 +6,7 @@ subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []
-[plugins."containerd.runtime.v1.linux"]
+[plugins."io.containerd.runtime.v1.linux"]
 # shim binary name/path
 shim = "containerd-shim"
 # runtime binary name/path


### PR DESCRIPTION
### What this PR does / why we need it

Fixes the containerd config that was breaking the service in flatcar 3602.* versions. 

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

 _Will trigger those later after some testing for other changes._

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->


