### PR TITLE
Move other values to global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move Helm values property `.Values.connectivity` to `.Values.global.connectivity`.
 - Move Helm values property `.Values.controlPlane` to `.Values.global.controlPlane`.
 - Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
+- Move Helm values property `.Values.managementCluster` to `.Values.global.managementCluster`.
+- Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
 
 ### Added
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -244,7 +244,9 @@ Node pools of the cluster. If not specified, this defaults to the value of `inte
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
 | `cluster-shared` | **Library chart**|**Type:** `object`<br/>|
+| `managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
 | `provider` | **Cluster API provider name**|**Type:** `string`<br/>|
 
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -233,13 +233,18 @@ Node pools of the cluster. If not specified, this defaults to the value of `inte
 | `global.nodePools.PATTERN.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
 
+### Other global
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
+
 ### Other
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
 | `cluster-shared` | **Library chart**|**Type:** `object`<br/>|
-| `managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
 | `provider` | **Cluster API provider name**|**Type:** `string`<br/>|
 
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -30,6 +30,7 @@ Properties within the `.global.connectivity` object
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.connectivity.availabilityZoneUsageLimit` | **Availability zones** - Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.|**Type:** `integer`<br/>**Default:** `3`|
+| `global.connectivity.baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
 | `global.connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
 | `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.connectivity.bastion.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"t3.small"`|
@@ -243,7 +244,6 @@ Node pools of the cluster. If not specified, this defaults to the value of `inte
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
 | `cluster-shared` | **Library chart**|**Type:** `object`<br/>|
 | `provider` | **Cluster API provider name**|**Type:** `string`<br/>|
 

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -2,6 +2,7 @@ global:
   metadata:
     organization: "test"
   connectivity:
+    baseDomain: example.com
     containerRegistries:
       with-auth.example.com:
       - endpoint: with-auth.example.com
@@ -16,4 +17,3 @@ global:
       instanceTypeOverrides:
         - r6i.xlarge
         - m5.xlarge
-baseDomain: example.com

--- a/helm/cluster-aws/ci/test-mc-proxy.yaml
+++ b/helm/cluster-aws/ci/test-mc-proxy.yaml
@@ -4,8 +4,8 @@ global:
     organization: test
     servicePriority: lowest
   connectivity:
+    baseDomain: example.com
     proxy:
       enabled: true
       httpProxy: http://proxy.mcproxy.example.com:4000
       httpsProxy: http://proxy.mcproxy.example.com:4000
-baseDomain: example.com

--- a/helm/cluster-aws/ci/test-spot-instances.yaml
+++ b/helm/cluster-aws/ci/test-spot-instances.yaml
@@ -3,6 +3,8 @@ global:
     name: test-wc-minimal
     organization: test
     servicePriority: lowest
+  connectivity:
+    baseDomain: example.com
   nodePools:
     pool0:
       maxSize: 2
@@ -10,4 +12,3 @@ global:
       spotInstances:
         enabled: true
         maxPrice: 1.2
-baseDomain: example.com

--- a/helm/cluster-aws/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-aws/ci/test-wc-minimal-values.yaml
@@ -3,4 +3,5 @@ global:
     name: test-wc-minimal
     organization: test
     servicePriority: lowest
-baseDomain: example.com
+  connectivity:
+    baseDomain: example.com

--- a/helm/cluster-aws/files/etc/teleport.yaml
+++ b/helm/cluster-aws/files/etc/teleport.yaml
@@ -22,9 +22,9 @@ ssh_service:
     command: [/opt/teleport-node-role.sh]
     period: 1m0s
   labels:
-    mc: {{ .Values.managementCluster }}
+    mc: {{ .Values.global.managementCluster }}
     {{- $clusterName := include "resource.default.name" $ }}    
-    {{- if ne .Values.managementCluster $clusterName }}
+    {{- if ne .Values.global.managementCluster $clusterName }}
     cluster: {{ include "resource.default.name" $ }}
     {{- end }}
     baseDomain: {{ .Values.baseDomain }}

--- a/helm/cluster-aws/files/etc/teleport.yaml
+++ b/helm/cluster-aws/files/etc/teleport.yaml
@@ -27,6 +27,6 @@ ssh_service:
     {{- if ne .Values.global.managementCluster $clusterName }}
     cluster: {{ include "resource.default.name" $ }}
     {{- end }}
-    baseDomain: {{ .Values.baseDomain }}
+    baseDomain: {{ .Values.global.connectivity.baseDomain }}
 proxy_service:
   enabled: "no"

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -1,5 +1,5 @@
 {{- define "aws-cluster" }}
-{{- if and (regexMatch "\\.internal$" (required "baseDomain is required" .Values.baseDomain)) (eq (required "global.connectivity.dns.mode required" .Values.global.connectivity.dns.mode) "public") }}
+{{- if and (regexMatch "\\.internal$" (required "baseDomain is required" .Values.global.connectivity.baseDomain)) (eq (required "global.connectivity.dns.mode required" .Values.global.connectivity.dns.mode) "public") }}
 {{- fail "global.connectivity.dns.mode=public cannot be combined with a '*.internal' baseDomain since reserved-as-private TLDs are not propagated to public DNS servers and therefore crucial DNS records such as api.<baseDomain> cannot be looked up" }}
 {{- end }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -92,14 +92,14 @@ spec:
       apiServer:
         timeoutForControlPlane: 20m
         certSANs:
-          - "api.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
+          - "api.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.global.connectivity.baseDomain }}"
           - 127.0.0.1
           {{- if .Values.global.controlPlane.apiExtraCertSANs -}}
           {{- toYaml .Values.global.controlPlane.apiExtraCertSANs | nindent 10 }}
           {{- end }}
         extraArgs:
           cloud-provider: external
-          service-account-issuer: "https://irsa.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.baseDomain }}"
+          service-account-issuer: "https://irsa.{{ include "resource.default.name" $ }}.{{ required "The baseDomain value is required" .Values.global.connectivity.baseDomain }}"
           {{- if .Values.global.controlPlane.oidc.issuerUrl }}
           {{- with .Values.global.controlPlane.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -87,7 +87,7 @@ giantswarm.io/prevent-deletion: "true"
 {{- end -}}
 
 {{- define "noProxyList" -}}
-127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.global.connectivity.network.vpcCidr }},{{ join "," $.Values.global.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.global.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.baseDomain }},elb.amazonaws.com,{{ $.Values.global.connectivity.proxy.noProxy }}
+127.0.0.1,localhost,svc,local,169.254.169.254,{{ $.Values.global.connectivity.network.vpcCidr }},{{ join "," $.Values.global.connectivity.network.services.cidrBlocks }},{{ join "," $.Values.global.connectivity.network.pods.cidrBlocks }},{{ include "resource.default.name" $ }}.{{ $.Values.global.connectivity.baseDomain }},elb.amazonaws.com,{{ $.Values.global.connectivity.proxy.noProxy }}
 {{- end -}}
 {{- define "proxyFiles" -}}
 - path: /etc/systemd/system/containerd.service.d/http-proxy.conf

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
   values:
     ipam:
       mode: kubernetes
-    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}
+    k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: '6443'
     kubeProxyReplacement: strict
     hubble:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -136,6 +136,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "baseDomain": {
+            "type": "string",
+            "title": "Base DNS domain"
+        },
         "cluster-shared": {
             "type": "object",
             "title": "Library chart"
@@ -951,6 +955,11 @@
                     "default": "1.23.5"
                 }
             }
+        },
+        "managementCluster": {
+            "type": "string",
+            "title": "Management cluster",
+            "description": "Name of the Cluster API cluster managing this workload cluster."
         },
         "provider": {
             "type": "string",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -707,6 +707,11 @@
                         }
                     }
                 },
+                "managementCluster": {
+                    "type": "string",
+                    "title": "Management cluster",
+                    "description": "Name of the Cluster API cluster managing this workload cluster."
+                },
                 "metadata": {
                     "type": "object",
                     "title": "Metadata",
@@ -946,11 +951,6 @@
                     "default": "1.23.5"
                 }
             }
-        },
-        "managementCluster": {
-            "type": "string",
-            "title": "Management cluster",
-            "description": "Name of the Cluster API cluster managing this workload cluster."
         },
         "provider": {
             "type": "string",

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -136,10 +136,6 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "baseDomain": {
-            "type": "string",
-            "title": "Base DNS domain"
-        },
         "cluster-shared": {
             "type": "object",
             "title": "Library chart"
@@ -162,6 +158,10 @@
                             "title": "Availability zones",
                             "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
                             "default": 3
+                        },
+                        "baseDomain": {
+                            "type": "string",
+                            "title": "Base DNS domain"
                         },
                         "bastion": {
                             "type": "object",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2954

:warning: This is a Helm values breaking change, so it will require adjusting Helm values for all cluster when doing the upgrade.

### What this PR does / why we need it

We have ported all provider-independent Cluster API resources to `cluster` chart, which was phase 1 of restructuring of cluster-<provider> apps, see https://github.com/giantswarm/roadmap/issues/2742 for more details. Now we want to use `cluster` chart in `cluster-aws` and remove all provider-independent Cluster API resources from `cluster-aws`.

In order to do so, first we have to refactor `cluster-aws` Helm values, so that `cluster` chart can read provider-independent values it needs. For that, we have to move current top-level properties to be under `Values.global`.

This pull request makes the following changes to Helm values:
- Move Helm values property `.Values.managementCluster` to `.Values.global.managementCluster`.
- Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
