### PR TITLE
Move Values.providerSpecific to Values.global.providerSpecific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move Helm values property `.Values.nodePools` to `.Values.global.nodePools`.
 - Move Helm values property `.Values.managementCluster` to `.Values.global.managementCluster`.
 - Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
+- Move Helm values property `.Values.providerSpecific` to `.Values.global.providerSpecific`.
 
 ### Added
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -13,16 +13,16 @@ schemadocs generate helm/cluster-aws/values.schema.json -o helm/cluster-aws/READ
 <!-- DOCS_START -->
 
 ### AWS settings
-Properties within the `.providerSpecific` top-level object
+Properties within the `.global.providerSpecific` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `providerSpecific.additionalResourceTags` | **Additional resource tags** - Additional tags to add to AWS resources created by the cluster.|**Type:** `object`<br/>|
-| `providerSpecific.additionalResourceTags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
-| `providerSpecific.ami` | **Amazon machine image (AMI)** - If specified, this image will be used to provision EC2 instances.|**Type:** `string`<br/>|
-| `providerSpecific.awsClusterRoleIdentityName` | **Cluster role identity name** - Name of an AWSClusterRoleIdentity object. This in turn refers to the IAM role used to create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create all resources in that account. Note: This name does not refer directly to an IAM role name/ARN.|**Type:** `string`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{1,63}$`<br/>**Default:** `"default"`|
-| `providerSpecific.flatcarAwsAccount` | **AWS account owning Flatcar image** - AWS account ID owning the Flatcar Container Linux AMI.|**Type:** `string`<br/>**Default:** `"706635527432"`|
-| `providerSpecific.region` | **Region**|**Type:** `string`<br/>|
+| `global.providerSpecific.additionalResourceTags` | **Additional resource tags** - Additional tags to add to AWS resources created by the cluster.|**Type:** `object`<br/>|
+| `global.providerSpecific.additionalResourceTags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
+| `global.providerSpecific.ami` | **Amazon machine image (AMI)** - If specified, this image will be used to provision EC2 instances.|**Type:** `string`<br/>|
+| `global.providerSpecific.awsClusterRoleIdentityName` | **Cluster role identity name** - Name of an AWSClusterRoleIdentity object. This in turn refers to the IAM role used to create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create all resources in that account. Note: This name does not refer directly to an IAM role name/ARN.|**Type:** `string`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{1,63}$`<br/>**Default:** `"default"`|
+| `global.providerSpecific.flatcarAwsAccount` | **AWS account owning Flatcar image** - AWS account ID owning the Flatcar Container Linux AMI.|**Type:** `string`<br/>**Default:** `"706635527432"`|
+| `global.providerSpecific.region` | **Region**|**Type:** `string`<br/>|
 
 ### Connectivity
 Properties within the `.global.connectivity` object

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -26,12 +26,12 @@ metadata:
 spec:
   additionalTags:
     giantswarm.io/cluster: {{ include "resource.default.name" $ }}
-    {{- if .Values.providerSpecific.additionalResourceTags -}}{{- toYaml .Values.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
+    {{- if .Values.global.providerSpecific.additionalResourceTags -}}{{- toYaml .Values.global.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
   bastion:
     enabled: false
   identityRef:
     kind: AWSClusterRoleIdentity
-    {{- with .Values.providerSpecific.awsClusterRoleIdentityName }}
+    {{- with .Values.global.providerSpecific.awsClusterRoleIdentityName }}
     name: {{ . | quote }}
     {{- end }}
   controlPlaneLoadBalancer:

--- a/helm/cluster-aws/templates/_awsregion.tpl
+++ b/helm/cluster-aws/templates/_awsregion.tpl
@@ -2,7 +2,7 @@
 If no region is provided in the values we'll attempt to look it up based on the region used by the management cluster
 */}}
 {{- define "aws-region" }}
-{{- $region := .Values.providerSpecific.region }}
+{{- $region := .Values.global.providerSpecific.region }}
 {{- if not $region }}
 {{- $nodes :=  (lookup "v1" "Node" "" "" ).items }}
 {{- if $nodes }}

--- a/helm/cluster-aws/templates/_bastion.tpl
+++ b/helm/cluster-aws/templates/_bastion.tpl
@@ -8,7 +8,7 @@ instanceType: {{ .Values.global.connectivity.bastion.instanceType }}
 cloudInit: {}
 imageLookupBaseOS: flatcar-stable
 imageLookupFormat: {{ "capa-ami-{{.BaseOS}}-v{{.K8sVersion}}-gs" }}
-imageLookupOrg: "{{ .Values.providerSpecific.flatcarAwsAccount }}"
+imageLookupOrg: "{{ .Values.global.providerSpecific.flatcarAwsAccount }}"
 iamInstanceProfile: {{ include "resource.default.name" $ }}-bastion
 publicIP: {{ if eq .Values.global.connectivity.vpcMode "private" }}false{{else}}true{{end}}
 sshKeyName: ""

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -279,7 +279,7 @@ and is used to join the node to the teleport cluster.
 {{- end -}}
 
 {{- define "ami" }}
-{{- with .Values.providerSpecific.ami }}
+{{- with .Values.global.providerSpecific.ami }}
 ami:
   id: {{ . | quote }}
 {{- else -}}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -764,6 +764,45 @@
                             "$ref": "#/$defs/machinePool"
                         }
                     }
+                },
+                "providerSpecific": {
+                    "type": "object",
+                    "title": "AWS settings",
+                    "properties": {
+                        "additionalResourceTags": {
+                            "type": "object",
+                            "title": "Additional resource tags",
+                            "description": "Additional tags to add to AWS resources created by the cluster.",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/awsResourceTagValue"
+                            }
+                        },
+                        "ami": {
+                            "type": "string",
+                            "title": "Amazon machine image (AMI)",
+                            "description": "If specified, this image will be used to provision EC2 instances."
+                        },
+                        "awsClusterRoleIdentityName": {
+                            "type": "string",
+                            "title": "Cluster role identity name",
+                            "description": "Name of an AWSClusterRoleIdentity object. This in turn refers to the IAM role used to create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create all resources in that account. Note: This name does not refer directly to an IAM role name/ARN.",
+                            "$comment": "See also https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html#awsclusterroleidentity",
+                            "default": "default",
+                            "maxLength": 63,
+                            "minLength": 1,
+                            "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$"
+                        },
+                        "flatcarAwsAccount": {
+                            "type": "string",
+                            "title": "AWS account owning Flatcar image",
+                            "description": "AWS account ID owning the Flatcar Container Linux AMI.",
+                            "default": "706635527432"
+                        },
+                        "region": {
+                            "type": "string",
+                            "title": "Region"
+                        }
+                    }
                 }
             }
         },
@@ -964,45 +1003,6 @@
         "provider": {
             "type": "string",
             "title": "Cluster API provider name"
-        },
-        "providerSpecific": {
-            "type": "object",
-            "title": "AWS settings",
-            "properties": {
-                "additionalResourceTags": {
-                    "type": "object",
-                    "title": "Additional resource tags",
-                    "description": "Additional tags to add to AWS resources created by the cluster.",
-                    "additionalProperties": {
-                        "$ref": "#/$defs/awsResourceTagValue"
-                    }
-                },
-                "ami": {
-                    "type": "string",
-                    "title": "Amazon machine image (AMI)",
-                    "description": "If specified, this image will be used to provision EC2 instances."
-                },
-                "awsClusterRoleIdentityName": {
-                    "type": "string",
-                    "title": "Cluster role identity name",
-                    "description": "Name of an AWSClusterRoleIdentity object. This in turn refers to the IAM role used to create all AWS cloud resources when creating the cluster. The role can be in another AWS account in order to create all resources in that account. Note: This name does not refer directly to an IAM role name/ARN.",
-                    "$comment": "See also https://cluster-api-aws.sigs.k8s.io/topics/multitenancy.html#awsclusterroleidentity",
-                    "default": "default",
-                    "maxLength": 63,
-                    "minLength": 1,
-                    "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$"
-                },
-                "flatcarAwsAccount": {
-                    "type": "string",
-                    "title": "AWS account owning Flatcar image",
-                    "description": "AWS account ID owning the Flatcar Container Linux AMI.",
-                    "default": "706635527432"
-                },
-                "region": {
-                    "type": "string",
-                    "title": "Region"
-                }
-            }
         }
     }
 }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -60,6 +60,9 @@ global:
   metadata:
     preventDeletion: false
     servicePriority: highest
+  providerSpecific:
+    awsClusterRoleIdentityName: default
+    flatcarAwsAccount: "706635527432"
 internal:
   cgroupsv1: false
   kubernetesVersion: 1.24.14
@@ -84,6 +87,3 @@ kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io
   tag: 1.23.5
-providerSpecific:
-  awsClusterRoleIdentityName: default
-  flatcarAwsAccount: "706635527432"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2954

:warning: This is a Helm values breaking change, so it will require adjusting Helm values for all cluster when doing the upgrade.

### What this PR does / why we need it

We have ported all provider-independent Cluster API resources to `cluster` chart, which was phase 1 of restructuring of cluster-<provider> apps, see https://github.com/giantswarm/roadmap/issues/2742 for more details. Now we want to use `cluster` chart in `cluster-aws` and remove all provider-independent Cluster API resources from `cluster-aws`.

In order to do so, first we have to refactor `cluster-aws` Helm values, so that `cluster` chart can read provider-independent values it needs. For that, we have to move current top-level properties to be under `Values.global`.

This pull request moves `Values.providerSpecific` to `Values.global.providerSpecific`. While this property is not provider-independent, it has to be visible from the Helm context of `cluster` chart, as the `cluster` chart will need to render machine templates from `cluster-$provider` in order to correctly calculate hash used for resource name suffixes.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
