### PR TITLE
Change schema validation allowing to add additional properties in `global`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change schema validation allowing to add additional properties in `global`.
 - Support longer node pool names and allow dashes
 
 ### Fixed

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -205,13 +205,6 @@ Properties within the `.metadata` top-level object
 | `metadata.organization` | **Organization**|**Type:** `string`<br/>|
 | `metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
 
-### Metadata
-Properties within the `.global.metadata` object
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `global.metadata.preventDeletion` | **Prevent cluster deletion**|**Type:** `boolean`<br/>**Default:** `false`|
-
 ### Node pools
 Properties within the `.nodePools` top-level object
 Node pools of the cluster. If not specified, this defaults to the value of `internal.nodePools`.

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -692,7 +692,7 @@
             "type": "object",
             "title": "Global properties",
             "description": "Properties that are available to all charts and subcharts.",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "metadata": {
                     "type": "object",


### PR DESCRIPTION
### What this PR does / why we need it

Allowing to add additonial properties into global is needed for adding cluster catalog values like `baseDomain` and `managementCluster` into cluster-aws app.

We will create PR's to change cluster catalog values, e.g https://github.com/giantswarm/giantswarm-management-clusters/blob/main/management-clusters/grizzly/catalogs/patches/appcatalog-cluster-patch.yaml moving them to `global` ...


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites