### PR TITLE
Label worker nodes with the 'node.kubernetes.io/worker' label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Label worker nodes with the `node.kubernetes.io/worker: ""` label.
+
 ## [0.49.0] - 2023-11-23
 
 ### Changed

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -122,7 +122,7 @@ spec:
         feature-gates: CronJobTimeZone=true
         healthz-bind-address: 0.0.0.0
         node-ip: ${COREOS_EC2_IPV4_LOCAL}
-        node-labels: role=worker,giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ $name }},{{- join "," $value.customNodeLabels }}
+        node-labels: role=worker,node-role.kubernetes.io/worker="",giantswarm.io/machine-pool={{ include "resource.default.name" $ }}-{{ $name }},{{- join "," $value.customNodeLabels }}
         v: "2"
       name: ${COREOS_EC2_HOSTNAME}
       {{- if $value.customNodeTaints }}


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
