### PR TITLE
Use 443 as default api-server Load Balancer port

### DIFF
--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,4 +1,4 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
-  - cluster-catalog=https://giantswarm.github.io/cluster-test-catalog
+  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,3 +1,4 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
+  - cluster-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,4 +1,3 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
-  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CI: trigger automated e2e tests on Renovate PRs.
 - Add new annotation for vintage irsa domain which is only used for migrating vintage clusters.
+- Use 443 as the default api-server Load Balancer port.
 
 ## [0.56.0] - 2024-01-08
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.6.5
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.1.2
-digest: sha256:72494b88feb8c524b6606c19d25da96e8fb9c1baf5d4b33a6f7b6619b16a0fe3
-generated: "2023-12-26T13:56:08.291564+01:00"
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 0.1.2-d138c04fda050ebebb2684022cecff04ce5c14d6
+digest: sha256:e769ef62d61e045397f00a63fc5646faa8af978c000b99bb67b892a4ae3fe57c
+generated: "2024-01-09T16:54:15.616372029+02:00"

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.6.5
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-test-catalog
-  version: 0.1.2-d138c04fda050ebebb2684022cecff04ce5c14d6
-digest: sha256:e769ef62d61e045397f00a63fc5646faa8af978c000b99bb67b892a4ae3fe57c
-generated: "2024-01-09T16:54:15.616372029+02:00"
+  repository: https://giantswarm.github.io/cluster-catalog
+  version: 0.2.1
+digest: sha256:74568140b761d4ca79240257c7a5a576528b8b5f29d1989b2b81b261ec56f676
+generated: "2024-01-17T16:05:30.149986552+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -20,4 +20,4 @@ dependencies:
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
     version: "0.2.1"
-    repository: "https://giantswarm.github.io/cluster-test-catalog"
+    repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.6.5"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.1.2-d138c04fda050ebebb2684022cecff04ce5c14d6"
+    version: "0.1.2-0b27c5813e64a0100f12e66d4c019c6904efe29d"
     repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.6.5"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.1.2-0b27c5813e64a0100f12e66d4c019c6904efe29d"
+    version: "0.1.2-fe7dea3b2a502a836e73ad2a00c0379f1c67806d"
     repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.6.5"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.1.2-58409653646cd1fbda234de053eee46179133ee3"
+    version: "0.2.1"
     repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.6.5"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.1.2-fe7dea3b2a502a836e73ad2a00c0379f1c67806d"
+    version: "0.1.2-58409653646cd1fbda234de053eee46179133ee3"
     repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.6.5"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.1.2"
-    repository: "https://giantswarm.github.io/cluster-catalog"
+    version: "0.1.2-d138c04fda050ebebb2684022cecff04ce5c14d6"
+    repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -136,6 +136,7 @@ Properties within the `.global.controlPlane` object
 | `global.controlPlane.apiExtraCertSANs` | **API extra cert SANs** - Extra certs SANs passed to the kubeadmcontrolplane CR.|**Type:** `array`<br/>|
 | `global.controlPlane.apiExtraCertSANs[*]` | **cert SAN**|**Type:** `string`<br/>|
 | `global.controlPlane.apiMode` | **API mode** - Whether the Kubernetes API server load balancer should be reachable from the internet (public) or internal only (private).|**Type:** `string`<br/>**Default:** `"public"`|
+| `global.controlPlane.apiServerPort` | **API server port** - The public facing API server Load Balancer port.|**Type:** `integer`<br/>**Default:** `443`|
 | `global.controlPlane.containerdVolumeSizeGB` | **Containerd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `global.controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `global.controlPlane.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"r6i.xlarge"`|

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -136,7 +136,7 @@ Properties within the `.global.controlPlane` object
 | `global.controlPlane.apiExtraCertSANs` | **API extra cert SANs** - Extra certs SANs passed to the kubeadmcontrolplane CR.|**Type:** `array`<br/>|
 | `global.controlPlane.apiExtraCertSANs[*]` | **cert SAN**|**Type:** `string`<br/>|
 | `global.controlPlane.apiMode` | **API mode** - Whether the Kubernetes API server load balancer should be reachable from the internet (public) or internal only (private).|**Type:** `string`<br/>**Default:** `"public"`|
-| `global.controlPlane.apiServerPort` | **API server port** - The public facing API server Load Balancer port.|**Type:** `integer`<br/>**Default:** `443`|
+| `global.controlPlane.apiServerPort` | **API server port** - The API server Load Balancer port. This option sets the Spec.ClusterNetwork.APIServerPort field on the Cluster CR. In CAPI this field isn't used currently. It is instead used in providers. In CAPA this sets only the public facing port of the Load Balancer. In CAPZ both the public facing and the destination port are set to this value. CAPV and CAPVCD do not use it.|**Type:** `integer`<br/>**Default:** `443`|
 | `global.controlPlane.containerdVolumeSizeGB` | **Containerd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `global.controlPlane.etcdVolumeSizeGB` | **Etcd volume size (GB)**|**Type:** `integer`<br/>**Default:** `100`|
 | `global.controlPlane.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"r6i.xlarge"`|

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -4,7 +4,7 @@
 ipam:
   mode: kubernetes
 k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
-k8sServicePort: '6443'
+k8sServicePort: '443'
 kubeProxyReplacement: strict
 hubble:
   relay:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -691,7 +691,7 @@
                         "apiServerPort": {
                             "type": "integer",
                             "title": "API server port",
-                            "description": "The public facing API server Load Balancer port.",
+                            "description": "The API server Load Balancer port. This option sets the Spec.ClusterNetwork.APIServerPort field on the Cluster CR. In CAPI this field isn't used currently. It is instead used in providers. In CAPA this sets only the public facing port of the Load Balancer. In CAPZ both the public facing and the destination port are set to this value. CAPV and CAPVCD do not use it.",
                             "default": 443,
                             "maximum": 65535,
                             "minimum": 0

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -692,7 +692,7 @@
                             "type": "integer",
                             "title": "API server port",
                             "description": "The public facing API server Load Balancer port.",
-                            "default": 6443,
+                            "default": 443,
                             "maximum": 65535,
                             "minimum": 0
                         },

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -688,6 +688,14 @@
                             ],
                             "default": "public"
                         },
+                        "apiServerPort": {
+                            "type": "integer",
+                            "title": "API server port",
+                            "description": "The public facing API server Load Balancer port.",
+                            "default": 6443,
+                            "maximum": 65535,
+                            "minimum": 0
+                        },
                         "containerdVolumeSizeGB": {
                             "type": "integer",
                             "title": "Containerd volume size (GB)",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -71,8 +71,8 @@ global:
     vpcEndpointMode: GiantSwarmManaged
     vpcMode: public
   controlPlane:
-    apiServerPort: 443
     apiMode: public
+    apiServerPort: 443
     containerdVolumeSizeGB: 100
     etcdVolumeSizeGB: 100
     instanceType: r6i.xlarge

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -71,6 +71,7 @@ global:
     vpcEndpointMode: GiantSwarmManaged
     vpcMode: public
   controlPlane:
+    apiServerPort: 443
     apiMode: public
     containerdVolumeSizeGB: 100
     etcdVolumeSizeGB: 100


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
