### PR TITLE
bump kubernetes version to 1.25.16

### DIFF
--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,4 +1,3 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
-  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,3 +1,4 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
+  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not hardcode cilium k8s service port. Use `global.controlPlane.apiServerPort`.
 
+### Changed 
+
+- Bumped kubernetes version to 1.25.16. This change also enforces PSS.
+
 ## [0.59.0] - 2024-01-23
 
 ### Changed

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.6.5
+  version: 0.7.0
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.2.1
-digest: sha256:74568140b761d4ca79240257c7a5a576528b8b5f29d1989b2b81b261ec56f676
-generated: "2024-01-17T16:05:30.149986552+02:00"
+  version: 0.6.0
+digest: sha256:5cd1118360bdb28bc1342f64c61ab4bf5b123a037f70be92286d85e3b5a0a705
+generated: "2024-01-25T15:50:42.5140142+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.2.1-82903698cc61aa0bef5a00525ca13bee5f3aec7d"
-    repository: "https://giantswarm.github.io/cluster-test-catalog"
+    version: "0.6.0"
+    repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,8 +16,8 @@ restrictions:
     - capa
 dependencies:
   - name: cluster-shared
-    version: "0.6.5"
+    version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.2.1"
-    repository: "https://giantswarm.github.io/cluster-catalog"
+    version: "0.2.1-82903698cc61aa0bef5a00525ca13bee5f3aec7d"
+    repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -168,7 +168,7 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | :----------- | :-------------- | :--------------- |
 | `internal.cgroupsv1` | **CGroups v1** - Force use of CGroups v1 for whole cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
-| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.24.16"`|
+| `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.24.7"`<br/>**Default:** `"1.25.16"`|
 | `internal.migration` | **Migration values** - Section used for migration of cluster from vintage to CAPI|**Type:** `object`<br/>|
 | `internal.migration.apiBindPort` | **Kubernetes API bind port** - Kubernetes API bind port used for kube api pod|**Type:** `integer`<br/>**Default:** `6443`|
 | `internal.migration.controlPlaneExtraFiles` | **Control Plane extra files** - Additional fiels that will be provisioned to control-plane nodes, reference is from secret in the same namespace.|**Type:** `array`<br/>|
@@ -278,6 +278,13 @@ Node pools of the cluster. If not specified, this defaults to the value of `inte
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
+
+### Pod Security Standards
+Properties within the `.global.podSecurityStandards` object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.podSecurityStandards.enforced` | **Enforced**|**Type:** `boolean`<br/>**Default:** `true`|
 
 ### Other
 

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -118,7 +118,7 @@ spec:
           audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
           api-audiences: "sts.amazonaws.com{{ if hasPrefix "cn-" (include "aws-region" .) }}.cn{{ end }}"
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
-          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,PodSecurityPolicy
+          enable-admission-plugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PersistentVolumeClaimResize,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
           feature-gates: CronJobTimeZone=true
           kubelet-preferred-address-types: InternalIP
           profiling: "false"

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -6,10 +6,10 @@ proxy:
   noProxy: "{{ include "noProxyList" $ }}"
   http: {{ .Values.global.connectivity.proxy.httpProxy | quote }}
   https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
+{{- end }}
 global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}
-{{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -6,6 +6,9 @@ proxy:
   noProxy: "{{ include "noProxyList" $ }}"
   http: {{ .Values.global.connectivity.proxy.httpProxy | quote }}
   https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
+global:
+  podSecurityStandards:
+    enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -36,6 +36,9 @@ extraPolicies:
     enabled: {{ $.Values.global.connectivity.proxy.enabled }}
     httpProxy: {{ $.Values.global.connectivity.proxy.httpProxy | quote }}
     httpsProxy: {{ $.Values.global.connectivity.proxy.httpsProxy | quote }}
+global:
+  podSecurityStandards:
+    enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -6,10 +6,10 @@ proxy:
   noProxy: "{{ include "noProxyList" $ }}"
   http: {{ .Values.global.connectivity.proxy.httpProxy | quote }}
   https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
+{{- end }}
 global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}
-{{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -6,6 +6,9 @@ proxy:
   noProxy: "{{ include "noProxyList" $ }}"
   http: {{ .Values.global.connectivity.proxy.httpProxy | quote }}
   https: {{ .Values.global.connectivity.proxy.httpsProxy | quote }}
+global:
+  podSecurityStandards:
+    enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/helm/cluster-aws/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-aws/templates/coredns-helmrelease.yaml
@@ -9,6 +9,9 @@ cluster:
       clusterIPRange: {{ first .Values.global.connectivity.network.services.cidrBlocks | quote }}
     DNS:
       IP: {{ include "clusterDNS" $ | quote }}
+global:
+  podSecurityStandards:
+    enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -1,6 +1,8 @@
 {{- include "validation" . }}
+{{- if semverCompare "<1.25.0" .Values.internal.kubernetesVersion -}}
 ---
 {{- include "psps" . }}
+{{- end }}
 ---
 {{- include "aws-cluster" . }}
 ---

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -873,6 +873,17 @@
                         }
                     }
                 },
+                "podSecurityStandards": {
+                    "type": "object",
+                    "title": "Pod Security Standards",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean",
+                            "title": "Enforced",
+                            "default": true
+                        }
+                    }
+                },
                 "providerSpecific": {
                     "type": "object",
                     "title": "AWS settings",
@@ -936,7 +947,7 @@
                     "examples": [
                         "1.24.7"
                     ],
-                    "default": "1.24.16"
+                    "default": "1.25.16"
                 },
                 "migration": {
                     "type": "object",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -88,12 +88,14 @@ global:
   metadata:
     preventDeletion: false
     servicePriority: highest
+  podSecurityStandards:
+    enforced: true
   providerSpecific:
     awsClusterRoleIdentityName: default
     flatcarAwsAccount: "706635527432"
 internal:
   cgroupsv1: false
-  kubernetesVersion: 1.25.15
+  kubernetesVersion: 1.25.16
   migration:
     apiBindPort: 6443
   nodePools:

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -93,7 +93,7 @@ global:
     flatcarAwsAccount: "706635527432"
 internal:
   cgroupsv1: false
-  kubernetesVersion: 1.24.16
+  kubernetesVersion: 1.25.15
   migration:
     apiBindPort: 6443
   nodePools:


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
