### PR TITLE
Bump cilium-app to v0.19.2 (upgrades Cilium to v1.14.5 and fixes a `CiliumNetworkPolicy` definition for reaching coredns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump cilium-app to v0.19.2 (upgrades Cilium to v1.14.5 and fixes a `CiliumNetworkPolicy` definition for reaching coredns)
+
 ## [0.57.0] - 2024-01-10
 
 ### Added
@@ -185,6 +189,7 @@ rm catalog.yaml
 
 - Change schema validation allowing to add additional properties in `global`.
 - Support longer node pool names and allow dashes.
+- Bump cilium-app to v0.18.0 (upgrades Cilium to v1.14.3)
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.18.0
+      version: 0.19.2
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
### What this PR does / why we need it

Towards

- https://github.com/giantswarm/roadmap/issues/3155
- https://github.com/giantswarm/roadmap/issues/3006
- https://github.com/giantswarm/roadmap/issues/2563

I also fixed the changelog which was missing the earlier Cilium v1.14.3 bump. The Renovate PR didn't include that, so it should be listed explicitly because the changes from Cilium v1.13.x can be major.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Skipping since E2E tests are currently not working