### PR TITLE
Fix removing allow-all Cilium network policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump cilium-app to v0.19.2 (upgrades Cilium to v1.14.5 and fixes a `CiliumNetworkPolicy` definition for reaching coredns)
 
+### Fixed
+
+- Fix removing allow-all Cilium network policies
+
 ## [0.57.0] - 2024-01-10
 
 ### Added
@@ -21,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Remove allow-all cilium network policies.
+- Remove allow-all Cilium network policies.
 
 ## [0.56.0] - 2024-01-08
 

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -20,7 +20,7 @@ hubble:
         effect: "NoSchedule"
 defaultPolicies:
   enabled: false
-  removed: true
+  remove: true
 
   tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
### What this PR does / why we need it

Fix for typo in https://github.com/giantswarm/cluster-aws/pull/475/commits/7794c8d80cf1a8dd8f6ef380314c19962714e423 (went into v0.57.0)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Skipping because tests aren't working right now