### PR TITLE
Don't hardcode cilium k8s service port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not hardcode cilium k8s service port. Use `global.controlPlane.apiServerPort`.
+
 ## [0.59.0] - 2024-01-23
 
 ### Changed

--- a/helm/cluster-aws/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cilium-helmrelease.yaml
@@ -4,7 +4,7 @@
 ipam:
   mode: kubernetes
 k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
-k8sServicePort: '443'
+k8sServicePort: '{{ .Values.global.controlPlane.apiServerPort }}'
 kubeProxyReplacement: strict
 hubble:
   relay:


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
