### PR TITLE
Include cluster-test-catalog in the CI

### DIFF
--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,3 +1,6 @@
 ---
 chart-repos:
   - cluster-catalog=https://giantswarm.github.io/cluster-catalog
+  # We also add cluster-test-catalog, so we can more easily test dev builds of subcharts.
+  # Charts from cluster-test-catalog should be used only for testing purposes.
+  - cluster-test-catalog=https://giantswarm.github.io/cluster-test-catalog

--- a/.github/workflows/zz_generated.diff_helm_render_templates.yaml
+++ b/.github/workflows/zz_generated.diff_helm_render_templates.yaml
@@ -82,6 +82,11 @@ jobs:
           mkdir -p /tmp/${{ matrix.values }}
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
+          
+          # We also add cluster-test-catalog so we can more easily test dev builds of subcharts.
+          # Charts from cluster-test-catalog should be used only for testing purposes.
+          helm repo add cluster-test-catalog https://giantswarm.github.io/cluster-test-catalog/
+          
           helm dependency build helm/${{ github.event.repository.name }}
           helm template -n org-giantswarm -f "helm/${{ github.event.repository.name }}/ci/ci-values.yaml" -f "${{ matrix.values }}" "helm/${{ github.event.repository.name }}" > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow customers to specify optional extraConfigs in HelmRelease apps.
+- Include cluster-test-catalog in the CI, so we can more easily test dev builds of subcharts.
 
 ### Changed
 


### PR DESCRIPTION
### What this PR does / why we need it

Include cluster-test-catalog in the CI, so we can more easily test dev builds of subcharts.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
