### PR TITLE
Remove unnecessary architect brackets cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `cluster.connectivity.proxy.noProxy` Helm template from cluster chart to render NO_PROXY in cluster-aws.
 - Rename CI files, so they are used in GitHub action that checks Helm rendering.
 - Remove ingress and egress rules from the security group that AWS creates by default when creating a new VPC.
+- Remove unnecessary architect brackets cleanup.
+- Use CI values to render templates locally.
 
 ## [0.60.0] - 2024-01-29
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,9 +1,6 @@
 .PHONY: template
 template: ## Output the rendered template yaml
-	@cd helm/cluster-aws && \
-		sed -i 's/version: \[/version: 1 #\[/' Chart.yaml && \
-		helm template . && \
-		sed -i 's/version: 1 #\[/version: \[/' Chart.yaml
+	@cd helm/cluster-aws && helm template . -f ci/ci-values.yaml
 
 ensure-schema-gen:
 	@helm schema-gen --help &>/dev/null || helm plugin install https://github.com/mihaisee/helm-schema-gen.git
@@ -14,7 +11,4 @@ schema-gen: ensure-schema-gen ## Generates the values schema file
 
 .PHONY: update-chart-deps
 update-chart-deps: ## Update chart dependencies to latest (matching) version
-	@cd helm/cluster-aws && \
-	sed -i.bk 's/version: \[\[ .Version \]\]/version: 1/' Chart.yaml && \
-	helm dependency update && \
-	mv Chart.yaml.bk Chart.yaml
+	@cd helm/cluster-aws && helm dependency update


### PR DESCRIPTION
Remove unnecessary architect brackets cleanup and use CI values to render templates locally

### What this PR does / why we need it

cluster-aws now uses app-build-suite, so `Version` in Chart.yaml does not have `[...]` anymore.

This PR also adds usage of CI files when running `make template` locally, as otherwise it just fails due to missing required values.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
