### PR TITLE
Remove duplicate containerd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove duplicate registry config as it's already deployed by the cluster chart.
+- Remove duplicate containerd config as it's already deployed by the cluster chart.
 
 ## [0.60.1] - 2024-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove duplicate registry config as it's already deployed by the cluster chart.
+
 ## [0.60.1] - 2024-02-05
 
 ### Added

--- a/helm/cluster-aws/templates/_registry-secret.yaml
+++ b/helm/cluster-aws/templates/_registry-secret.yaml
@@ -1,8 +1,0 @@
-{{- define "registry-secret" }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "resource.default.name" $ }}-registry-configuration
-data:
-  registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
-{{- end -}}

--- a/helm/cluster-aws/templates/list.yaml
+++ b/helm/cluster-aws/templates/list.yaml
@@ -6,8 +6,6 @@
 ---
 {{- include "aws-cluster" . }}
 ---
-{{- include "registry-secret" . }}
----
 {{- include "control-plane" . }}
 ---
 {{- include "machine-pools" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3047

### What this PR does / why we need it

Remove duplicate containerd config as it's already deployed by the cluster chart. The secret is ATM deployed from both cluster-aws and cluster chart, which causes transient Helm errors which slows down the cluster creation.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
