### PR TITLE
update network-policies helm chart to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update network-policies to avoid installing deny-all policy.
+
 ## [0.62.0] - 2024-02-14
 
 ### Added

--- a/helm/cluster-aws/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-aws/templates/netpol-helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     spec:
       chart: network-policies
-      version: 0.0.3
+      version: 0.0.4
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-cluster


### PR DESCRIPTION
This version disables the installation of the CoreDNS
ClusterCiliumNetworkPolicy; which effectivelly implements a deny-all in
all namespaces.

Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
