### PR TITLE
downgrade kubernetes version to upgrade it back to 1.25.16

### DIFF
--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.0
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.9.0
-digest: sha256:8b65df9a95abeded68472ae5331b3f017f58d2f71df9e5d67d30cc4d4b3c71ae
-generated: "2024-02-21T14:56:50.883299+01:00"
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 0.9.1-0609dbc393ab5868dccb85837d56872283a6476e
+digest: sha256:b32ae391116ea19e8bfc47df2bb8a0767668bc16db139057309d5ed04e546444
+generated: "2024-02-22T18:01:18.989909+03:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.9.0"
-    repository: "https://giantswarm.github.io/cluster-catalog"
+    version: "0.9.1-0609dbc393ab5868dccb85837d56872283a6476e"
+    repository: "https://giantswarm.github.io/cluster-test-catalog"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -197,7 +197,7 @@ global:
     flatcarAwsAccount: "706635527432"
 internal:
   cgroupsv1: false
-  kubernetesVersion: 1.25.16
+  kubernetesVersion: 1.25.15
   migration:
     apiBindPort: 6443
   sandboxContainerImage:


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
