### PR TITLE
Chart: Bump `cluster` to v0.9.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Bump `cluster` to v0.9.1. ([#521](https://github.com/giantswarm/cluster-aws/pull/521))
+
 ## [0.63.0] - 2024-02-22
 
 ### Changed

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.7.0
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.9.0
-digest: sha256:8b65df9a95abeded68472ae5331b3f017f58d2f71df9e5d67d30cc4d4b3c71ae
-generated: "2024-02-21T14:56:50.883299+01:00"
+  version: 0.9.1
+digest: sha256:487652f84db445490806b4cb1553e81d49917131445b23661908be4f0dd09036
+generated: "2024-02-22T15:55:24.67835+01:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.9.0"
+    version: "0.9.1"
     repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
### What this PR does / why we need it

This PR bumps the chart dependency of `cluster` to v0.9.1.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
