### PR TITLE
Use port 443 for API server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix allow list API port 443.
+
 ## [0.64.1] - 2024-02-29
 
 ### Changed

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -47,8 +47,8 @@ spec:
     ingressRules:
     - description: "Kubernetes API"
       protocol: tcp
-      fromPort: 6443
-      toPort: 6443
+      fromPort: 443
+      toPort: 443
       # We append the Giant Swarm VPN IPs (internal link: https://github.com/giantswarm/vpn/tree/master/hosts_inventory, https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/tc_api_whitelisting/)
       cidrBlocks: {{- toYaml ((concat .Values.global.controlPlane.loadBalancerIngressAllowCidrBlocks (list "95.179.153.65/32" "185.102.95.187/32")) | uniq) | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

loadBalancerIngressAllowCidrBlocks should create rules for port 443

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
