### PR TITLE
Pass `clusterID` to `aws-ebs-csi-driver` app's values for volume tagging purposes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass `clusterID` to `aws-ebs-csi-driver` app's values for volume tagging purposes.
+
 ## [0.64.2] - 2024-03-06
 
 ### Changed

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -1,6 +1,7 @@
 {{/* Default Helm values for the app */}}
 {{/* See schema for the appropriate app version here https://github.com/giantswarm/aws-ebs-csi-driver-app/blob/master/helm/aws-ebs-csi-driver-app/values.schema.json */}}
 {{- define "defaultAwsEbsCsiDriverHelmValues" }}
+clusterID: {{ include "resource.default.name" $ }}
 extraVolumeTags: {{ include "resource.default.additionalTags" . | nindent 2 }} 
 {{- if (.Values.global.connectivity.proxy).enabled }}
 proxy:


### PR DESCRIPTION
### What this PR does / why we need it

towards: https://github.com/giantswarm/giantswarm/issues/30160

aws-ebs-csi-driver app does not tag ebs volumes correctly

![Screenshot_20240306_141818](https://github.com/giantswarm/cluster-aws/assets/868430/0bb3c6bc-9203-44ff-a2cd-5b9a6d7d9a4c)

after this PR the needed helm values are set while installing the default app and tagging happens correctly

![Screenshot_20240306_141533](https://github.com/giantswarm/cluster-aws/assets/868430/2d7407e1-156a-4e30-a276-94bb28647a71)



### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
