### PR TITLE
Update Chart.lock with current dep version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update Chart.lock with current version of dependencies.
+
 ## [0.66.0] - 2024-03-21
 
 ### Added

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.0
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-test-catalog
-  version: 0.13.0-c8930e9f64b5870b05e13eb0db3b0542de8d34b2
-digest: sha256:48652d0004f0c993fa31143ed3d1676018d661d8978634feacac9241b179cb15
-generated: "2024-03-15T14:31:53.926359195+01:00"
+  repository: https://giantswarm.github.io/cluster-catalog
+  version: 0.14.0
+digest: sha256:223ef0d522dc762d07dd87332a1769843acd2ca668092b0938c79e7931d423f3
+generated: "2024-03-21T15:15:47.440948978+01:00"


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

### What this PR does / why we need it

This is kind of a hotfix because Chart deps are broken at the moment in v0.66.0

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
