### PR TITLE
cluster chart 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Bump `cluster` to v0.15.0.
+
 ## [0.67.0] - 2024-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Chart: Bump `cluster` to v0.15.0.
+- Chart: Bump `cluster` to v0.16.0.
 
 ## [0.67.0] - 2024-03-26
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.7.0
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.15.0
-digest: sha256:920ce3aca11eee2732984fb0280056ad8da27677541818beec68b284b29362d9
-generated: "2024-03-26T12:32:04.806409+01:00"
+  version: 0.16.0
+digest: sha256:f4229142c22c8db410b779923f6dbe390210fddfa3361619384ea6e85fff76b2
+generated: "2024-03-26T14:51:10.937353+01:00"

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.7.0
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.14.0
-digest: sha256:223ef0d522dc762d07dd87332a1769843acd2ca668092b0938c79e7931d423f3
-generated: "2024-03-21T15:15:47.440948978+01:00"
+  version: 0.15.0
+digest: sha256:920ce3aca11eee2732984fb0280056ad8da27677541818beec68b284b29362d9
+generated: "2024-03-26T12:32:04.806409+01:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.14.0"
+    version: "0.15.0"
     repository: "https://giantswarm.github.io/cluster-catalog"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -19,5 +19,5 @@ dependencies:
     version: "0.7.0"
     repository: "https://giantswarm.github.io/cluster-catalog"
   - name: cluster
-    version: "0.15.0"
+    version: "0.16.0"
     repository: "https://giantswarm.github.io/cluster-catalog"


### PR DESCRIPTION
Towards:
- https://github.com/giantswarm/roadmap/issues/3339
- https://github.com/giantswarm/roadmap/issues/3342

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->