### PR TITLE
Chart: Bump `cluster` chart v0.18.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cluster chart to v0.18.0. This updates teleport node labels.
+- Update cluster chart to v0.18.0. This updates teleport node labels and will roll nodes.
 - Update cluster chart to v0.17.0. This updates cilium app from v0.21.0 to v0.22.0.
 
 ## [0.69.0] - 2024-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Availability Zones in helm/cluster-aws/files/azs-in-region.yaml
 - AMI: Use new AMI which includes latest teleport binary v15.1.7
+- Chart: Bump `cluster` to v0.18.0.
 
 ## [0.68.0] - 2024-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update cluster chart to v0.18.0. This updates teleport node labels.
 - Update cluster chart to v0.17.0. This updates cilium app from v0.21.0 to v0.22.0.
 
 ## [0.69.0] - 2024-04-11
@@ -25,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Availability Zones in helm/cluster-aws/files/azs-in-region.yaml
 - AMI: Use new AMI which includes latest teleport binary v15.1.7
-- Chart: Bump `cluster` to v0.18.0.
 
 ## [0.68.0] - 2024-03-27
 

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.17.0
+  version: 0.18.0
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.0
-digest: sha256:91cbc8d53af2aa365f8a0cf6a0884d486d10db6a3479a9da45134f47b62bfd96
-generated: "2024-04-11T14:17:36.361859+02:00"
+digest: sha256:1ce40f738ca0a191ac8400d41ee55b0d81698e5ba904ee563f758c88ae805b5a
+generated: "2024-04-11T15:48:38.252484+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,7 +16,7 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "0.17.0"
+    version: "0.18.0"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.0"


### PR DESCRIPTION
### What this PR does / why we need it
- Bumps the cluster chart https://github.com/giantswarm/cluster/pull/141

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
