### PR TITLE
Use new AMI which includes latest teleport binary v15.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- AMI: Use new AMI which includes latest teleport binary v15.1.7
+- Chart: Bump `cluster` to v0.18.0.
+
 ## [0.68.0] - 2024-03-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - AMI: Use new AMI which includes latest teleport binary v15.1.7
-- Chart: Bump `cluster` to v0.18.0.
 
 ## [0.68.0] - 2024-03-27
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -22,7 +22,7 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.ami` | **Amazon machine image (AMI)** - If specified, this image will be used to provision EC2 instances.|**Type:** `string`<br/>|
 | `global.providerSpecific.awsClusterRoleIdentityName` | **Cluster role identity name** - Name of an AWSClusterRoleIdentity object. Learn more at https://docs.giantswarm.io/getting-started/cloud-provider-accounts/cluster-api/aws/#configure-the-awsclusterroleidentity .|**Type:** `string`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{1,63}$`<br/>**Default:** `"default"`|
 | `global.providerSpecific.flatcarAwsAccount` | **AWS account owning Flatcar image** - AWS account ID owning the Flatcar Container Linux AMI.|**Type:** `string`<br/>**Default:** `"706635527432"`|
-| `global.providerSpecific.osImageVariant` | **OS image variant**|**Type:** `string`<br/>**Default:** `"2"`|
+| `global.providerSpecific.osImageVariant` | **OS image variant**|**Type:** `string`<br/>**Default:** `"3"`|
 | `global.providerSpecific.region` | **Region**|**Type:** `string`<br/>|
 
 ### Apps

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -1142,7 +1142,7 @@
                         "osImageVariant": {
                             "type": "string",
                             "title": "OS image variant",
-                            "default": "2"
+                            "default": "3"
                         },
                         "region": {
                             "type": "string",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -218,7 +218,7 @@ global:
   providerSpecific:
     awsClusterRoleIdentityName: default
     flatcarAwsAccount: "706635527432"
-    osImageVariant: "2"
+    osImageVariant: "3"
 internal:
   migration: {}
 kubectlImage:


### PR DESCRIPTION
### What this PR does / why we need it

- As part of https://github.com/giantswarm/giantswarm/issues/30385 we need to update the teleport binary from v13.x to v15.x.
- AMI `capa-ami-flatcar-stable-v1.25.16-3-gs` has been created. [See Tekton logs here](https://tekton.ci.giantswarm.io/#/namespaces/capi-image-builder/pipelineruns/manual-capa-build-capi-image-x9n74?pipelineTask=build-image&step=build-image&view=logs)
![image](https://github.com/giantswarm/cluster-aws/assets/5674762/0d37fb12-34e9-44f1-baf2-eeceacf3ff63)
- Tested on `grizzly / puru0402`
![Screenshot 2024-04-01 at 10 08 27 PM](https://github.com/giantswarm/cluster-aws/assets/5674762/b443fc74-a847-4347-a6e4-e1e6a658c744)

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
