### PR TITLE
Update cluster chart to v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cluster chart to v0.17.0. This updates cilium app from v0.21.0 to v0.22.0.
+
 ## [0.69.0] - 2024-04-11
 
 ### Added

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.16.0
+  version: 0.17.0
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.0
-digest: sha256:8d873c00f25149349c2f4271b20e47098659bdd81163ec81b39a3e208b5f7fa1
-generated: "2024-04-10T22:31:51.362516+02:00"
+digest: sha256:91cbc8d53af2aa365f8a0cf6a0884d486d10db6a3479a9da45134f47b62bfd96
+generated: "2024-04-11T14:17:36.361859+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,7 +16,7 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "0.16.0"
+    version: "0.17.0"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.0"


### PR DESCRIPTION
### What this PR does / why we need it

Update cluster chart to v0.17.0. This updates:
- cilium app from v0.21.0 to v0.22.0.
- network-policies app from v0.0.4 to v0.1.0.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the e2e tests, remove the following line and add the `skip/ci` label to skip the check

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
