### PR TITLE
aws-pod-identity-china

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set token audience for `aws-pod-identity-webhook` based on AWS region.
+
 ## [0.76.0] - 2024-05-14
 
 ### ⚠️ Breaking change

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -1,6 +1,6 @@
 {{- define "awsPodIdentityWebhookValuesDefault" }}
   aws:
-    tokenAudience: {{ include "awsApiServerApiAudiences" $ }}
+    tokenAudience: {{ include "awsApiServerApiAudiences" $ | trim  -}}
 {{- end }}
 {{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" $ ) | fromYaml -}}
 {{- $customAwsPodIdentityWebhookValues := .Values.global.apps.awsPodIdentityWebhook.values -}}

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -1,8 +1,8 @@
 {{- define "awsPodIdentityWebhookValuesDefault" }}
   aws:
-    tokenAudience: {{  include "awsApiServerApiAudiences" . }}
+    tokenAudience: {{ include "awsApiServerApiAudiences" $ }}
 {{- end }}
-{{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" .) | fromYaml -}}
+{{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" $ ) | fromYaml -}}
 {{- $customAwsPodIdentityWebhookValues := .Values.global.apps.awsPodIdentityWebhook.values -}}
 {{- if $customAwsPodIdentityWebhookValues -}}
 {{- $awsPodIdentityWebhookValues = mergeOverwrite $awsPodIdentityWebhookValues (deepCopy $customAwsPodIdentityWebhookValues) -}}

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -1,6 +1,6 @@
 {{- define "awsPodIdentityWebhookValuesDefault" }}
   aws:
-    tokenAudience: {{  include "awsApiServerApiAudiences" }}
+    tokenAudience: {{  include "awsApiServerApiAudiences" . }}
 {{- end }}
 {{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" .) | fromYaml -}}
 {{- $customAwsPodIdentityWebhookValues := .Values.global.apps.awsPodIdentityWebhook.values -}}

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.global.apps.awsPodIdentityWebhook.values -}}
+{{- define "awsPodIdentityWebhookValuesDefault" }}
+  aws:
+    tokenAudience: {{  include "awsApiServerApiAudiences" }}
+{{- end }}
+{{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" .) | fromYaml -}}
+{{- $customAwsPodIdentityWebhookValues := .Values.global.apps.awsPodIdentityWebhook.values -}}
+{{- if $customAwsPodIdentityWebhookValues -}}
+$awsPodIdentityWebhookValues = mergeOverwrite $awsPodIdentityWebhookValues (deepCopy $customAwsPodIdentityWebhookValues) -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,8 +16,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 data:
   values: |
-    {{- toYaml .Values.global.apps.awsPodIdentityWebhook.values | nindent 4 }}
-{{- end }}
+    {{- $awsPodIdentityWebhookValues | toYaml | nindent 4 }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -5,7 +5,7 @@
 {{- $awsPodIdentityWebhookValues := (include "awsPodIdentityWebhookValuesDefault" .) | fromYaml -}}
 {{- $customAwsPodIdentityWebhookValues := .Values.global.apps.awsPodIdentityWebhook.values -}}
 {{- if $customAwsPodIdentityWebhookValues -}}
-$awsPodIdentityWebhookValues = mergeOverwrite $awsPodIdentityWebhookValues (deepCopy $customAwsPodIdentityWebhookValues) -}}
+{{- $awsPodIdentityWebhookValues = mergeOverwrite $awsPodIdentityWebhookValues (deepCopy $customAwsPodIdentityWebhookValues) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3257
set API token audience for aws-pod-identity-webhook based on the region ( make specific change for china)