### PR TITLE
Updates aws-cloud-controller-manager-app to v1.25.14-gs3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update aws-cloud-controller-manager-app to v1.25.14-gs3.
+
 ## [0.76.1] - 2024-05-16
 
 ### Changed

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
       chart: aws-cloud-controller-manager-app
       # used by renovate
       # repo: giantswarm/aws-cloud-controller-manager-app
-      version: v1.25.14-gs2
+      version: v1.25.14-gs3
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/30671

Updates aws-cloud-controller-manager-app to latest to use new CPU requests.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
