### PR TITLE
Fix AWS pod identity webhook app userValues to be always rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set environmane variable `COREOS_EC2_HOSTNAME` to inject value to kubeadm configuration.
 - Update aws-cloud-controller-manager-app to v1.25.14-gs3.
 - Update cluster chart to v0.27.0. More details in [cluster chart v0.27.0 release notes](https://github.com/giantswarm/cluster/releases/tag/v0.27.0).
+- Always render `userConfig` valeus reference to configmap for `aws-pod-identity-webhook-app`.
 
 ## [0.76.1] - 2024-05-16
 

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -38,12 +38,10 @@ spec:
     configMap:
       name: {{ include "resource.default.name" . }}-cluster-values
       namespace: {{ .Release.Namespace }}
-  {{- if .Values.global.apps.awsPodIdentityWebhook.values }}
   userConfig:
     configMap:
       name: {{ include "resource.default.name" . }}-aws-pod-identity-webhook-user-values
       namespace: {{ .Release.Namespace }}
-  {{- end }}
   {{- if .Values.global.apps.awsPodIdentityWebhook.extraConfigs }}
   extraConfigs:
   {{- range .Values.global.apps.awsPodIdentityWebhook.extraConfigs }}


### PR DESCRIPTION
the configmap for the app si always rendered but the user config was not, this broke automatic detection for china values and broke the functionality
