### PR TITLE
Update cluster chart to 0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the Management Cluster name as a tag to the AWS resources created by CAPA.
 - Add the node pool name as a tag to the AWS resources associated with the node pool.
 
+### Changed
+
+- Update cluster chart to 0.33.1
+
 ## [1.0.0] - 2024-06-20
 
 ### Changed

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.33.0
+  version: 0.33.1
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:e0a52d1a4f74330deda661ac9cdf9cbf96123c49fce02e5847ee8f72735156b1
-generated: "2024-06-20T14:48:34.084622+02:00"
+digest: sha256:3a9b87e88a54d3030f4a743d2e0c1af942f54115d2beba28d853922c275721bb
+generated: "2024-07-04T17:14:02.139637139+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,7 +16,7 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "0.33.0"
+    version: "0.33.1"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"


### PR DESCRIPTION
### What this PR does / why we need it

We need [this fix](https://github.com/giantswarm/cluster/pull/242) from the cluster chart for kubernetes 1.27 to work properly.

Since we want the smallest possible change in releases (until v29), this simply bumps the cluster chart dependency from 0.33.0 to 0.33.1 and does not enable the GCS app by default like https://github.com/giantswarm/cluster-aws/pull/657

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
