### PR TITLE
Apps: Fix service monitor dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apps: Fix service monitor dependencies.
+
 ## [1.2.0] - 2024-07-22
 
 This release removes the `CronJobTimeZone` feature gate as it becomes stable and is included in Kubernetes v1.29.

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-servicemonitors-app.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-servicemonitors-app.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/managed-by: {{ .Chart.Name }}
   annotations:
-    app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-cert-manager
+    app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-prometheus-operator-crd
 spec:
   catalog: default
   name: aws-ebs-csi-driver-servicemonitors

--- a/helm/cluster-aws/templates/irsa-servicemonitors-app.yaml
+++ b/helm/cluster-aws/templates/irsa-servicemonitors-app.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/managed-by: {{ .Chart.Name }}
   annotations:
-    app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-cert-manager
+    app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-prometheus-operator-crd
 spec:
   catalog: default
   name: irsa-servicemonitors


### PR DESCRIPTION
### What this PR does / why we need it

I assume those two apps have been copied and pasted from AWS Pod Identity Webhook app and therefore still contained the `cert-manager` dependency. Actually they should depend on the `observability-bundle`.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
