### PR TITLE
Bump cluster chart to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cluster chart version to v1.0.0. This update adds MC Zot deployment as a registry mirror for `gsoci.azurecr.io` registry. This is the new default behavior.
+
 ## [1.2.1] - 2024-07-22
 
 ### Changed

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 0.36.0
+  version: 1.0.0
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:ac1d3ed36ee385a9309581226ed498713179341a1fbf51498ba11c5c27da7a30
-generated: "2024-07-19T14:16:51.33350574Z"
+digest: sha256:68d3cac7c3d274582555c4961171fd053f47e3e562885f3d992f64353a1f9398
+generated: "2024-07-24T14:57:58.852388376+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,7 +16,7 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "0.36.0"
+    version: "1.0.0"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -229,7 +229,7 @@ Advanced configuration of components that are running on all nodes.
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
-| `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}]}`|
+| `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{"docker.io":[{"endpoint":"registry-1.docker.io"},{"endpoint":"giantswarm.azurecr.io"}],"gsoci.azurecr.io":[{"endpoint":"gsoci.azurecr.io"}]}`|
 | `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
 | `global.components.containerd.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
@@ -243,6 +243,10 @@ Advanced configuration of components that are running on all nodes.
 | `global.components.containerd.localRegistryCache.mirroredRegistries` | **Registries to cache locally** - A list of registries that should be cached.|**Type:** `array`<br/>**Default:** `[]`|
 | `global.components.containerd.localRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
 | `global.components.containerd.localRegistryCache.port` | **Local port for the registry cache** - Port for the local registry cache under: http://127.0.0.1:<PORT>.|**Type:** `integer`<br/>**Default:** `32767`|
+| `global.components.containerd.managementClusterRegistryCache` | **Management cluster registry cache** - Caching container registry on a management cluster level.|**Type:** `object`<br/>|
+| `global.components.containerd.managementClusterRegistryCache.enabled` | **Enabled** - Enabling this will configure containerd to use management cluster's Zot registry service. To make use of it as a pull-through cache, you also have to specify registries to cache images for.|**Type:** `boolean`<br/>**Default:** `true`|
+| `global.components.containerd.managementClusterRegistryCache.mirroredRegistries` | **Registries to cache** - Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.|**Type:** `array`<br/>**Default:** `["gsoci.azurecr.io"]`|
+| `global.components.containerd.managementClusterRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
 | `global.components.selinux` | **SELinux** - Configuration of SELinux.|**Type:** `object`<br/>|
 | `global.components.selinux.mode` | **SELinux mode** - Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.|**Type:** `string`<br/>**Default:** `"permissive"`|
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -910,6 +910,11 @@
                                             {
                                                 "endpoint": "giantswarm.azurecr.io"
                                             }
+                                        ],
+                                        "gsoci.azurecr.io": [
+                                            {
+                                                "endpoint": "gsoci.azurecr.io"
+                                            }
                                         ]
                                     }
                                 },
@@ -943,6 +948,34 @@
                                             "title": "Local port for the registry cache",
                                             "description": "Port for the local registry cache under: http://127.0.0.1:<PORT>.",
                                             "default": 32767
+                                        }
+                                    }
+                                },
+                                "managementClusterRegistryCache": {
+                                    "type": "object",
+                                    "title": "Management cluster registry cache",
+                                    "description": "Caching container registry on a management cluster level.",
+                                    "required": [
+                                        "enabled"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "title": "Enabled",
+                                            "description": "Enabling this will configure containerd to use management cluster's Zot registry service. To make use of it as a pull-through cache, you also have to specify registries to cache images for.",
+                                            "default": true
+                                        },
+                                        "mirroredRegistries": {
+                                            "type": "array",
+                                            "title": "Registries to cache",
+                                            "description": "Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "default": [
+                                                "gsoci.azurecr.io"
+                                            ]
                                         }
                                     }
                                 }

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -295,10 +295,16 @@ global:
         docker.io:
           - endpoint: registry-1.docker.io
           - endpoint: giantswarm.azurecr.io
+        gsoci.azurecr.io:
+          - endpoint: gsoci.azurecr.io
       localRegistryCache:
         enabled: false
         mirroredRegistries: []
         port: 32767
+      managementClusterRegistryCache:
+        enabled: true
+        mirroredRegistries:
+          - gsoci.azurecr.io
     selinux:
       mode: permissive
   connectivity:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3069

### What this PR does / why we need it

This PR update cluster chart version to v1.0.0. Changes below are not breaking changes and this will be included in CAPA v25.1.0.

### Changed

- Update cluster chart version to v1.0.0. This update adds MC Zot deployment as a registry mirror for `gsoci.azurecr.io` registry. This is the new default behavior.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
