### PR TITLE
Update cluster chart to v1.1.0 and update "ami" template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `global.metadata.labels` to values schema. This field is used to add labels to the cluster resources.
 
+### Changed
+
+- Update cluster chart to v1.1.0.
+  - This sets cilium `kubeProxyReplacement` config to `"true"` instead to `"strict"` (`"strict"` has been deprecated since cilium v1.14, see [this upstream cilium](https://github.com/cilium/cilium/issues/32711) issue for more details).
+- Update `ami` named template to correctly render OS image name with the new format `flatcar-stable-<flatcar version>-kube-<kubernetes version>-tooling-<capi-image-builder version>-gs`.
+
 ## [1.3.0] - 2024-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!IMPORTANT]
+> Releases that include this cluster-aws version must have the `os-tooling` component in the Release resource `.spec.components`.
+> See `ami` changes below for more details about the change and see AWS (CAPA) release v29.0.0 for a Release resource example.
+
 ### Added
 
 - Add `global.metadata.labels` to values schema. This field is used to add labels to the cluster resources.

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
   repository: https://giantswarm.github.io/cluster-catalog
-  version: 1.0.0
+  version: 1.1.0
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:68d3cac7c3d274582555c4961171fd053f47e3e562885f3d992f64353a1f9398
-generated: "2024-07-24T14:57:58.852388376+02:00"
+digest: sha256:e6100484d42a4694c40281c6710af07892f82968423ae9fdc923834733a34698
+generated: "2024-08-07T11:06:05.905703759+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,7 +16,7 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "1.0.0"
+    version: "1.1.0"
     repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v29.0.0
+    version: v27.0.0-alpha.1
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: v29.0.0
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -61,7 +61,7 @@ giantswarm.io/prevent-deletion: "true"
 {{- end -}}
 
 {{- /*
-    "ami" named template renders YAML manifest tha tis the used in AWSMachineTemplate and in AWSMachinePool resources.
+    "ami" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
 
     This template is using "cluster.os.*" named templates that are defined in the cluster chart. For more details about
     how these templates work see cluster chart docs at https://github.com/giantswarm/cluster/tree/main/helm/cluster.

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -66,19 +66,12 @@ ami:
   id: {{ . | quote }}
 {{- else -}}
 ami: {}
-{{- /* Get Flatcar variant, which we use in image name suffix. This helper is defined in the cluster chart and it will
- get the variant number from the Release CR as cluster-aws is using new releases with Release CRs. */}}
-{{- $suffix := include "cluster.component.flatcar.variant" $ }}
-{{- /* Get Flatcar version. This helper is defined in the cluster chart and it will get the Flatcar version from the
- Release CR as cluster-aws is using new releases with Release CRs. */}}
+{{- /* Get Flatcar version. This helper is defined in the cluster chart. */}}
 imageLookupBaseOS: "{{ include "cluster.component.flatcar.version" $ }}"
-{{- if and $suffix (ne $suffix "N/A") }}
-{{- /* Build image name with Flatcar variant set. These images with the variant number in the suffix are currently built manually. */}}
-imageLookupFormat: {{ "flatcar-stable-{{.BaseOS}}-kube-v{{.K8sVersion}}" }}-alpha.{{$suffix}}
-{{- else }}
-{{- /* Build image name without Flatcar variant. These images without variant in the suffix are built by the CI. */}}
-imageLookupFormat: {{ "flatcar-stable-{{.BaseOS}}-kube-v{{.K8sVersion}}" }}-gs
-{{- end }}
+{{- /* Get OS tooling version, which we use in image name. */}}
+{{- $osToolingVersion := include "cluster.os.tooling.version" $ }}
+{{- /* Build the OS image name. The OS images are built automatically by the CI. */}}
+imageLookupFormat: {{ "flatcar-stable-{{.BaseOS}}-kube-{{.K8sVersion}}" }}-tooling-{{ $osToolingVersion }}-gs
 imageLookupOrg: "{{ if hasPrefix "cn-" (include "aws-region" .) }}306934455918{{else}}706635527432{{end}}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

### Changed

- Update cluster chart to v1.1.0.
  - This sets cilium `kubeProxyReplacement` config to `"true"` instead to `"strict"` (`"strict"` has been deprecated since cilium v1.14, see [this upstream cilium](https://github.com/cilium/cilium/issues/32711) issue for more details).
- Update `ami` named template to correctly render OS image name with the new format `flatcar-stable-<flatcar version>-kube-<kubernetes version>-tooling-<capi-image-builder version>-gs`.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->


<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->

Skipping e2e tests because they would run against release v28, while this change here can work only for CAPA release v29, since it requires new OS tooling component in the release.

This cluster-aws change has been tested in the releases repo PR [here](https://github.com/giantswarm/releases/pull/1337#issuecomment-2271400217). The e2e tests were successful :white_check_mark:.