### PR TITLE
Remove unused kubectl image Helm value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not allow additional properties in most values in order to avoid unnoticed typos
 
+### Removed
+
+- Remove unused kubectl image Helm value.
+
 ## [2.0.0] - 2024-08-07
 
 > [!IMPORTANT]

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -363,15 +363,6 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | `internal.migration` | **Migration values** - Section used for migration of cluster from vintage to CAPI|**Type:** `object`<br/>|
 | `internal.migration.irsaAdditionalDomain` | **IRSA additional domain** - Additional domain to be added to IRSA trust relationship.|**Type:** `string`<br/>|
 
-### Kubectl image
-Properties within the `.kubectlImage` top-level object
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `kubectlImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
-| `kubectlImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
-| `kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.23.5"`|
-
 ### Metadata
 Properties within the `.global.metadata` object
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -1777,27 +1777,6 @@
                 }
             }
         },
-        "kubectlImage": {
-            "type": "object",
-            "title": "Kubectl image",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "title": "Repository",
-                    "default": "giantswarm/kubectl"
-                },
-                "registry": {
-                    "type": "string",
-                    "title": "Registry",
-                    "default": "gsoci.azurecr.io"
-                },
-                "tag": {
-                    "type": "string",
-                    "title": "Tag",
-                    "default": "1.23.5"
-                }
-            }
-        },
         "managementCluster": {
             "type": "string",
             "title": "Management cluster",

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -382,7 +382,3 @@ global:
   release: {}
 internal:
   migration: {}
-kubectlImage:
-  name: giantswarm/kubectl
-  registry: gsoci.azurecr.io
-  tag: 1.23.5


### PR DESCRIPTION
Coming from `#area-kaas` Slack cenversation with @puja108.

### What this PR does / why we need it

Remove unused kubectl image Helm value. We probably forgot to remove this when we moved the functionality to cluster chart.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
