### PR TITLE
Validate that machine pool availability zones belong to the selected region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Do not allow additional properties in most values in order to avoid unnoticed typos
+- Do not allow additional properties in most values in order to avoid unnoticed typos.
+- Validate that machine pool availability zones belong to the selected region.
 
 ### Removed
 

--- a/helm/cluster-aws/templates/_awsazs.tpl
+++ b/helm/cluster-aws/templates/_awsazs.tpl
@@ -2,10 +2,20 @@
 If no availability zones are provided in the values we'll attempt to look it up based on the region specified in AWSCluster if its missing as well, AZs of the management cluster are used
 */}}
 {{- define "aws-availability-zones" }}
+{{- $region := include "aws-region" . }}
 {{- if .mp.availabilityZones }}
 {{- .mp.availabilityZones | toYaml }}
+{{- $isValid := true -}}
+{{- range $az := .mp.availabilityZones -}}
+  {{- $azRegion := (printf "%s" $az | trunc 9) -}}
+  {{- if ne $azRegion $region -}}
+    {{- $isValid = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $isValid -}}
+  {{- fail (printf "Invalid MachinePool Availability Zones provided for region %s. Availability Zones: %v" $region .mp.availabilityZones) -}}
+{{- end -}}
 {{- else }}
-{{- $region := include "aws-region" . }}
 {{- include "azs-in-region" (dict "region" $region  "Files" .Files ) }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-aws/templates/_awsazs.tpl
+++ b/helm/cluster-aws/templates/_awsazs.tpl
@@ -5,16 +5,11 @@ If no availability zones are provided in the values we'll attempt to look it up 
 {{- $region := include "aws-region" . | trim }}
 {{- if .mp.availabilityZones }}
 {{- .mp.availabilityZones | toYaml }}
-{{- $isValid := true -}}
-{{- range $az := .mp.availabilityZones -}}
-  {{- $azRegion := (printf "%s" $az | trunc 9) -}}
-  {{- if ne $azRegion $region -}}
-    {{- $isValid = false -}}
-  {{- end -}}
-{{- end -}}
-{{- if not $isValid -}}
-  {{- fail (printf "Invalid value in global.nodePools.*.availabilityZones: the specified availability zones %v are not in the cluster region %q" .mp.availabilityZones $region) -}}
-{{- end -}}
+{{- range $az := .mp.availabilityZones }}
+  {{- if not (hasPrefix $region $az) }}
+    {{- fail (printf "Invalid value in `global.nodePools.*.availabilityZones`: The specified availability zone %s is not in the cluster's region %s" $az $region) }}
+  {{- end }}
+{{- end }}
 {{- else }}
 {{- include "azs-in-region" (dict "region" $region  "Files" .Files ) }}
 {{- end }}

--- a/helm/cluster-aws/templates/_awsazs.tpl
+++ b/helm/cluster-aws/templates/_awsazs.tpl
@@ -2,7 +2,7 @@
 If no availability zones are provided in the values we'll attempt to look it up based on the region specified in AWSCluster if its missing as well, AZs of the management cluster are used
 */}}
 {{- define "aws-availability-zones" }}
-{{- $region := include "aws-region" . }}
+{{- $region := include "aws-region" . | trim }}
 {{- if .mp.availabilityZones }}
 {{- .mp.availabilityZones | toYaml }}
 {{- $isValid := true -}}
@@ -13,7 +13,7 @@ If no availability zones are provided in the values we'll attempt to look it up 
   {{- end -}}
 {{- end -}}
 {{- if not $isValid -}}
-  {{- fail (printf "Invalid MachinePool Availability Zones provided for region %s. Availability Zones: %v" $region .mp.availabilityZones) -}}
+  {{- fail (printf "Invalid value in global.nodePools.*.availabilityZones: the specified availability zones %v are not in the cluster region %q" .mp.availabilityZones $region) -}}
 {{- end -}}
 {{- else }}
 {{- include "azs-in-region" (dict "region" $region  "Files" .Files ) }}

--- a/helm/cluster-aws/templates/_awsazs.tpl
+++ b/helm/cluster-aws/templates/_awsazs.tpl
@@ -4,12 +4,12 @@ If no availability zones are provided in the values we'll attempt to look it up 
 {{- define "aws-availability-zones" }}
 {{- $region := include "aws-region" . | trim }}
 {{- if .mp.availabilityZones }}
-{{- .mp.availabilityZones | toYaml }}
 {{- range $az := .mp.availabilityZones }}
   {{- if not (hasPrefix $region $az) }}
     {{- fail (printf "Invalid value in `global.nodePools.*.availabilityZones`: The specified availability zone %s is not in the cluster's region %s" $az $region) }}
   {{- end }}
 {{- end }}
+{{- .mp.availabilityZones | toYaml }}
 {{- else }}
 {{- include "azs-in-region" (dict "region" $region  "Files" .Files ) }}
 {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

Sometimes when configuring node pools, users may forget to choose the right availability zones, and select AZs that differ from the selected region. This makes cluster creation to fail, but the user needs to investigate why the cluster is not coming up. Instead, it would be better to fail earlier, explaining the user what the error is.

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
