### PR TITLE
CI: Bump release version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not allow additional properties in most values in order to avoid unnoticed typos.
 - Validate that machine pool availability zones belong to the selected region.
+- CI: Bump release version. ([#792](https://github.com/giantswarm/cluster-aws/pull/792))
 
 ### Removed
 

--- a/helm/cluster-aws/ci/ci-values.yaml
+++ b/helm/cluster-aws/ci/ci-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/ci/test-eni-mode.yaml
+++ b/helm/cluster-aws/ci/test-eni-mode.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/ci/test-local-registry-cache-values.yaml
+++ b/helm/cluster-aws/ci/test-local-registry-cache-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/ci/test-mc-proxy-values.yaml
+++ b/helm/cluster-aws/ci/test-mc-proxy-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-mc-proxy
     organization: test

--- a/helm/cluster-aws/ci/test-multiple-authenticated-mirrors-values.yaml
+++ b/helm/cluster-aws/ci/test-multiple-authenticated-mirrors-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc
     organization: "test"

--- a/helm/cluster-aws/ci/test-network-topology-values.yaml
+++ b/helm/cluster-aws/ci/test-network-topology-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc-minimal
     organization: test

--- a/helm/cluster-aws/ci/test-spot-instances.yaml
+++ b/helm/cluster-aws/ci/test-spot-instances.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc-minimal
     organization: test

--- a/helm/cluster-aws/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-aws/ci/test-wc-minimal-values.yaml
@@ -1,6 +1,6 @@
 global:
   release:
-    version: v27.0.0-alpha.1
+    version: 29.1.0
   metadata:
     name: test-wc-minimal
     organization: test


### PR DESCRIPTION
### What this PR does / why we need it

This PR bumps the release version used in CI values to the latest available CAPA release.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
