### PR TITLE
Apps: Use `catalog` from Release CR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not allow additional properties in most values in order to avoid unnoticed typos.
 - Validate that machine pool availability zones belong to the selected region.
-- CI: Bump release version. ([#792](https://github.com/giantswarm/cluster-aws/pull/792))
+- CI: Bump release version.
+- Apps: Use `catalog` from Release CR.
 
 ### Removed
 

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -34,11 +34,10 @@ spec:
     spec:
       chart: aws-ebs-csi-driver-app
       {{- $_ := set $ "appName" "aws-ebs-csi-driver" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   dependsOn:
       - name: {{ include "resource.default.name" $ }}-cloud-provider-aws
         namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-servicemonitors-app.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-servicemonitors-app.yaml
@@ -17,11 +17,10 @@ metadata:
   annotations:
     app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-prometheus-operator-crd
 spec:
-  catalog: default
-  name: aws-ebs-csi-driver-servicemonitors
   {{- $_ := set $ "appName" "aws-ebs-csi-driver-servicemonitors" }}
-  {{- $appVersion := include "cluster.app.version" $ }}
-  version: {{ $appVersion }}
+  catalog: {{ include "cluster.app.catalog" $ }}
+  name: aws-ebs-csi-driver-servicemonitors
+  version: {{ include "cluster.app.version" $ }}
   namespace: kube-system
   config:
     configMap:

--- a/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
+++ b/helm/cluster-aws/templates/aws-pod-identity-webhook-app.yaml
@@ -30,11 +30,10 @@ metadata:
   annotations:
     app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-cert-manager
 spec:
-  catalog: default
-  name: aws-pod-identity-webhook
   {{- $_ := set $ "appName" "aws-pod-identity-webhook" }}
-  {{- $appVersion := include "cluster.app.version" $ }}
-  version: {{ $appVersion }}
+  catalog: {{ include "cluster.app.catalog" $ }}
+  name: aws-pod-identity-webhook
+  version: {{ include "cluster.app.version" $ }}
   namespace: kube-system
   config:
     configMap:

--- a/helm/cluster-aws/templates/cilium-crossplane-resources-app.yaml
+++ b/helm/cluster-aws/templates/cilium-crossplane-resources-app.yaml
@@ -21,18 +21,17 @@ metadata:
   name: {{ printf "%s-cilium-crossplane-resources" (include "resource.default.name" $) | quote }}
   namespace: {{ $.Release.Namespace | quote }}
 spec:
-  catalog: cluster
+  {{- $_ := set $ "appName" "cilium-crossplane-resources" }}
+  catalog: {{ include "cluster.app.catalog" $ }}
+  name: cilium-crossplane-resources
+  version: {{ include "cluster.app.version" $ }}
   install:
     timeout: "10m"
   upgrade:
     timeout: "10m"
   kubeConfig:
     inCluster: true # in management cluster context
-  name: cilium-crossplane-resources
   namespace: {{ $.Release.Namespace | quote }}
-  {{- $_ := set $ "appName" "cilium-crossplane-resources" }}
-  {{- $appVersion := include "cluster.app.version" $ }}
-  version: {{ $appVersion }}
   extraConfigs:
     # See above
     - kind: configMap

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -32,11 +32,10 @@ spec:
     spec:
       chart: aws-cloud-controller-manager-app
       {{- $_ := set $ "appName" "cloud-provider-aws" }}
-      {{- $appVersion := include "cluster.app.version" $ }}
-      version: {{ $appVersion }}
+      version: {{ include "cluster.app.version" $ }}
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
   dependsOn:
       - name: {{ include "resource.default.name" $ }}-vertical-pod-autoscaler-crd
         namespace: {{ $.Release.Namespace }}

--- a/helm/cluster-aws/templates/irsa-servicemonitors-app.yaml
+++ b/helm/cluster-aws/templates/irsa-servicemonitors-app.yaml
@@ -17,11 +17,10 @@ metadata:
   annotations:
     app-operator.giantswarm.io/depends-on: {{ include "resource.default.name" . }}-prometheus-operator-crd
 spec:
-  catalog: default
-  name: irsa-servicemonitors
   {{- $_ := set $ "appName" "irsa-servicemonitors" }}
-  {{- $appVersion := include "cluster.app.version" $ }}
-  version: {{ $appVersion }}
+  catalog: {{ include "cluster.app.catalog" $ }}
+  name: irsa-servicemonitors
+  version: {{ include "cluster.app.version" $ }}
   namespace: kube-system
   config:
     configMap:


### PR DESCRIPTION
### What this PR does / why we need it

This PR aligns the way we define the catalog of an app to the way we do it in the `cluster` chart and therefore allows setting a different catalog in the Release CR, which is sometimes required for testing apps during development, e.g. by setting `catalog: default-test`.

I came across this issue when forging CAPA v29.0.0, where I also needed to bump the `cloud-provider-aws` version.

As the current latest release CAPA v29.1.0 does not define the catalog for the `cilium-crossplane-resources` app, yet, this PR can not be properly tested as Cluster Test Suites pick the latest available release and patch the `cluster-aws` chart to the version provided by this PR. This issue is about to be fixed in this PR: https://github.com/giantswarm/releases/pull/1355. So please also have a look there and review it, if not already merged.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
