### PR TITLE
Chart: Update `cluster` to v1.4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cluster chart to v1.3.0.
+- Chart: Update `cluster` to v1.4.1.
 - Set provider specific configuration for cilium CNI ENI values.
 
 ### Removed

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-test-catalog
-  version: 1.0.1-8b685f8ebfe01cda642cf0016ce7a0986e24b108
+  repository: https://giantswarm.github.io/cluster-catalog
+  version: 1.4.1
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:aa9c1e149a683b95cbd3c58081a976f77f5bac6600e692adfaec2f0d1efd0ed5
-generated: "2024-09-19T21:58:15.578409+02:00"
+digest: sha256:346980c7aeada3705103241a499bc0b7246dda23aae74fee2956fc6f820e3fd0
+generated: "2024-09-23T18:51:21.211503+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,8 +16,8 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "1.0.1-8b685f8ebfe01cda642cf0016ce7a0986e24b108"  # TODO actually based on 1.3.0 tag, change to released `cluster` tag...
-    repository: https://giantswarm.github.io/cluster-test-catalog  # TODO ... + back to `cluster` catalog once tests succeed
+    version: "1.4.1"
+    repository: https://giantswarm.github.io/cluster-catalog
   - name: cluster-shared
     version: "0.7.1"
     repository: https://giantswarm.github.io/cluster-catalog


### PR DESCRIPTION
### What this PR does / why we need it

It updates the `cluster` chart to v1.4.1.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
