### PR TITLE
Chart: Update `cluster` to v1.0.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update `cluster` to v1.0.2.
+  - Chart: Add OS tooling named template.
+
 ## [1.3.2] - 2024-09-19
 
 ### Added

--- a/helm/cluster-aws/Chart.lock
+++ b/helm/cluster-aws/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cluster
-  repository: https://giantswarm.github.io/cluster-catalog
-  version: 1.0.1
+  repository: https://giantswarm.github.io/cluster-test-catalog
+  version: 1.4.1-29d86ff1ea1ce1a8c987be78d2d93f82040d0f7a
 - name: cluster-shared
   repository: https://giantswarm.github.io/cluster-catalog
   version: 0.7.1
-digest: sha256:62d157b208d68e6f61bfa0e73088dbcb241a09f6b1f8846c2a6b6f81b1e6a275
-generated: "2024-09-19T16:23:41.237563+02:00"
+digest: sha256:87c2d1e349fab82c05f0194048d5b1ef078c0a9e01e568bce62e6fbb732f4adf
+generated: "2024-09-30T16:38:35.620481+02:00"

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -16,8 +16,8 @@ restrictions:
     - capa
 dependencies:
   - name: cluster
-    version: "1.0.1"
-    repository: https://giantswarm.github.io/cluster-catalog
+    version: "1.4.1-29d86ff1ea1ce1a8c987be78d2d93f82040d0f7a"
+    repository: https://giantswarm.github.io/cluster-test-catalog
   - name: cluster-shared
     version: "0.7.1"
     repository: https://giantswarm.github.io/cluster-catalog

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -60,25 +60,26 @@ giantswarm.io/prevent-deletion: "true"
 - /opt/control-plane-config.sh
 {{- end -}}
 
+{{- /*
+    "ami" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
+
+    This template is using "cluster.os.*" named templates that are defined in the cluster chart. For more details about
+    how these templates work see cluster chart docs at https://github.com/giantswarm/cluster/tree/main/helm/cluster.
+*/}}
 {{- define "ami" }}
 {{- with .Values.global.providerSpecific.ami }}
 ami:
   id: {{ . | quote }}
 {{- else -}}
 ami: {}
-{{- /* Get Flatcar variant, which we use in image name suffix. This helper is defined in the cluster chart and it will
- get the variant number from the Release CR as cluster-aws is using new releases with Release CRs. */}}
-{{- $suffix := include "cluster.component.flatcar.variant" $ }}
-{{- /* Get Flatcar version. This helper is defined in the cluster chart and it will get the Flatcar version from the
- Release CR as cluster-aws is using new releases with Release CRs. */}}
-imageLookupBaseOS: "{{ include "cluster.component.flatcar.version" $ }}"
-{{- if and $suffix (ne $suffix "N/A") }}
-{{- /* Build image name with Flatcar variant set. These images with the variant number in the suffix are currently built manually. */}}
-imageLookupFormat: {{ "flatcar-stable-{{.BaseOS}}-kube-v{{.K8sVersion}}" }}-alpha.{{$suffix}}
-{{- else }}
-{{- /* Build image name without Flatcar variant. These images without variant in the suffix are built by the CI. */}}
-imageLookupFormat: {{ "flatcar-stable-{{.BaseOS}}-kube-v{{.K8sVersion}}" }}-gs
-{{- end }}
+{{- /* Get OS version. */}}
+imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
+{{- /* Get OS name, release channel and tooling version, which we use in the OS image name. */}}
+{{- $osName := include "cluster.os.name" $ }}
+{{- $osReleaseChannel := include "cluster.os.releaseChannel" $ }}
+{{- $osToolingVersion := include "cluster.os.tooling.version" $ }}
+{{- /* Build the OS image name. The OS images are built automatically by the CI. */}}
+imageLookupFormat: {{ $osName }}-{{$osReleaseChannel }}-{{ "{{.BaseOS}}-kube-{{.K8sVersion}}" }}-tooling-{{ $osToolingVersion }}-gs
 imageLookupOrg: "{{ if hasPrefix "cn-" (include "aws-region" .) }}306934455918{{else}}706635527432{{end}}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Back-port of https://github.com/giantswarm/cluster-aws/pull/747.