### PR TITLE
Bring back default for minHealthyPercentage

### DIFF
--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -79,7 +79,7 @@ spec:
   {{- end }}
   refreshPreferences:
     instanceWarmup: {{ $value.instanceWarmup | default 600 }}
-    minHealthyPercentage: {{ $value.minHealthyPercentage }}
+    minHealthyPercentage: {{ $value.minHealthyPercentage | default 90 }}
     maxHealthyPercentage: {{ $value.maxHealthyPercentage }}
   ignition:
     version: "3.4"


### PR DESCRIPTION
### What this PR does / why we need it

Apparently, helm does not use `default` from the schema. I removed this default in the previous PR, so I'm bringing it back.
