### PR TITLE
Only try to render subnet tags if they are defined by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only try to render subnet tags if they are defined by the user.
+
 ## [2.3.0] - 2024-10-17
 
 ### Added

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -123,7 +123,9 @@ spec:
       isPublic: {{ $subnet.isPublic | default false }}
       {{- if or $subnet.tags $cidr.tags }}
       tags:
+        {{- if $subnet.tags }}
         {{- toYaml $subnet.tags | nindent 8 }}
+        {{- end }}
         {{- if $cidr.tags }}
         {{- toYaml $cidr.tags | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

Otherwise, when no tags were assigned to the subnet, it would break the template.

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
