### PR TITLE
Values: Add `global.providerSpecific.controlPlaneAmi` & `global.providerSpecific.nodePoolAmi`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add aws-node-termination-handler bundle
+- Values: Add `global.providerSpecific.controlPlaneAmi` & `global.providerSpecific.nodePoolAmi`.
 
 ## [2.4.0] - 2024-11-12
 

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -24,9 +24,11 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.ami` | **Amazon machine image (AMI)** - If specified, this image will be used to provision EC2 instances.|**Type:** `string`<br/>|
 | `global.providerSpecific.awsAccountId` | **AWS Account ID** - Only used when rendering the chart template locally, you shouldn't use this value. Used to calculate the IRSA service account issuer when using the China region.|**Type:** `string`<br/>|
 | `global.providerSpecific.awsClusterRoleIdentityName` | **Cluster role identity name** - Name of an AWSClusterRoleIdentity object. Learn more at https://docs.giantswarm.io/getting-started/cloud-provider-accounts/cluster-api/aws/#configure-the-awsclusterroleidentity .|**Type:** `string`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{1,63}$`<br/>**Default:** `"default"`|
+| `global.providerSpecific.controlPlaneAmi` | **Amazon machine image (AMI) for control plane** - If specified, this image will be used to provision EC2 instances for the control plane.|**Type:** `string`<br/>|
 | `global.providerSpecific.flatcarAwsAccount` | **AWS account owning Flatcar image** - AWS account ID owning the Flatcar Container Linux AMI.|**Type:** `string`<br/>**Default:** `"706635527432"`|
 | `global.providerSpecific.instanceMetadataOptions` | **Instance metadata options** - Instance metadata options for the EC2 instances in the cluster.|**Type:** `object`<br/>|
 | `global.providerSpecific.instanceMetadataOptions.httpTokens` | **HTTP tokens** - The state of token usage for your instance metadata requests. If you set this parameter to `optional`, you can use either IMDSv1 or IMDSv2. If you set this parameter to `required`, you must use a IMDSv2 to access the instance metadata endpoint. Learn more at [What’s new in IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).|**Type:** `string`<br/>**Default:** `"required"`|
+| `global.providerSpecific.nodePoolAmi` | **Amazon machine image (AMI) for node pools** - If specified, this image will be used to provision EC2 instances for node pools.|**Type:** `string`<br/>|
 | `global.providerSpecific.region` | **Region**|**Type:** `string`<br/>|
 
 ### Apps

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -4,7 +4,12 @@ This function is used for both the `.Spec` value and as the data for the hash fu
 Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
 */}}
 {{- define "controlplane-awsmachinetemplate-spec" -}}
-{{- include "ami" $ }}
+{{- with (.Values.global.providerSpecific.controlPlaneAmi | default .Values.global.providerSpecific.ami) }}
+ami:
+  id: {{ . | quote }}
+{{- else }}
+{{- include "imageLookupParameters" $ }}
+{{- end }}
 {{- if $.Values.global.providerSpecific.additionalNodeTags }}
 additionalTags: {{ toYaml $.Values.global.providerSpecific.additionalNodeTags | nindent 2 }}
 {{- end }}

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -61,17 +61,12 @@ giantswarm.io/prevent-deletion: "true"
 {{- end -}}
 
 {{- /*
-    "ami" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
+    "imageLookupParameters" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
 
     This template is using "cluster.os.*" named templates that are defined in the cluster chart. For more details about
     how these templates work see cluster chart docs at https://github.com/giantswarm/cluster/tree/main/helm/cluster.
 */}}
-{{- define "ami" }}
-{{- with .Values.global.providerSpecific.ami }}
-ami:
-  id: {{ . | quote }}
-{{- else -}}
-ami: {}
+{{- define "imageLookupParameters" }}
 {{- /* Get OS version. */}}
 imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
 {{- /* Get OS name, release channel and tooling version, which we use in the OS image name. */}}
@@ -81,7 +76,6 @@ imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
 {{- /* Build the OS image name. The OS images are built automatically by the CI. */}}
 imageLookupFormat: {{ $osName }}-{{$osReleaseChannel }}-{{ "{{.BaseOS}}-kube-{{.K8sVersion}}" }}-tooling-{{ $osToolingVersion }}-gs
 imageLookupOrg: "{{ if hasPrefix "cn-" (include "aws-region" .) }}306934455918{{else}}706635527432{{end}}"
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -37,7 +37,12 @@ spec:
       - {{ index $tags (keys $tags | first) | quote }}
     {{- end }}
   awsLaunchTemplate:
-    {{- include "ami" $ | nindent 4 }}
+    {{- with ($.Values.global.providerSpecific.nodePoolAmi | default $.Values.global.providerSpecific.ami) }}
+    ami:
+      id: {{ . | quote }}
+    {{- else }}
+    {{- include "imageLookupParameters" $ | nindent 4 }}
+    {{- end }}
     iamInstanceProfile: nodes-{{ $name }}-{{ include "resource.default.name" $ }}
     instanceType: {{ $value.instanceType | default "r6i.xlarge" }}
     rootVolume:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -1756,6 +1756,11 @@
                             "minLength": 1,
                             "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$"
                         },
+                        "controlPlaneAmi": {
+                            "type": "string",
+                            "title": "Amazon machine image (AMI) for control plane",
+                            "description": "If specified, this image will be used to provision EC2 instances for the control plane."
+                        },
                         "flatcarAwsAccount": {
                             "type": "string",
                             "title": "AWS account owning Flatcar image",
@@ -1779,6 +1784,11 @@
                                     "default": "required"
                                 }
                             }
+                        },
+                        "nodePoolAmi": {
+                            "type": "string",
+                            "title": "Amazon machine image (AMI) for node pools",
+                            "description": "If specified, this image will be used to provision EC2 instances for node pools."
                         },
                         "region": {
                             "type": "string",


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/32219.

I tested this change by manually creating a cluster with the AMI ID set to the AMI the lookup mechanism would select. When upgrading the cluster to a different release which would have led to a different AMI, the node pools didn't get rolled and stayed with the old AMI. The moment I removed the explicit AMI ID, the nodes began to roll as their AMI changed.

In general this change is meant to have the AMI for the control plane and node pools configurable separately. Apart from that, it enables customers to have their node pools stay on an older version while only upgrading the control plane and then upgrade the node pools once their control plane reached the desired version.

Starting of Kubernetes v1.25, `kubelet` can skew up to three versions from the control plane. So this would mean customers could upgrade their control plane from v1.25 to v1.26 to v1.27 to v1.28 with only rolling worker nodes once.

Of course this is just a side effect and not a feature customers should use heavily. Therefore this workaround/hack requires you to configure an AMI ID instead of just defining a Kubernetes version. This AMI ID is region-specific and so I hope customers get they should not use this hack long-term and really only for speeding up their upgrades.

So to make it clear: This change is meant to have AMIs configurable separately. Full stop. Its main purpose is **not** to have node pools stay on an older version while upgrading a cluster. This is just a positive side effect customers _can_ benefit from. 😉

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->