### PR TITLE
Values: Add `global.providerSpecific.controlPlaneAmi` & `global.providerSpecific.nodePoolAmi`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Values: Add `global.providerSpecific.controlPlaneAmi` & `global.providerSpecific.nodePoolAmi`.
+
 ## [1.3.4] - 2024-10-15
 
 ### Changed

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -21,9 +21,11 @@ Properties within the `.global.providerSpecific` object
 | `global.providerSpecific.additionalResourceTags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
 | `global.providerSpecific.ami` | **Amazon machine image (AMI)** - If specified, this image will be used to provision EC2 instances.|**Type:** `string`<br/>|
 | `global.providerSpecific.awsClusterRoleIdentityName` | **Cluster role identity name** - Name of an AWSClusterRoleIdentity object. Learn more at https://docs.giantswarm.io/getting-started/cloud-provider-accounts/cluster-api/aws/#configure-the-awsclusterroleidentity .|**Type:** `string`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{1,63}$`<br/>**Default:** `"default"`|
+| `global.providerSpecific.controlPlaneAmi` | **Amazon machine image (AMI) for control plane** - If specified, this image will be used to provision EC2 instances for the control plane.|**Type:** `string`<br/>|
 | `global.providerSpecific.flatcarAwsAccount` | **AWS account owning Flatcar image** - AWS account ID owning the Flatcar Container Linux AMI.|**Type:** `string`<br/>**Default:** `"706635527432"`|
 | `global.providerSpecific.instanceMetadataOptions` | **Instance metadata options** - Instance metadata options for the EC2 instances in the cluster.|**Type:** `object`<br/>|
 | `global.providerSpecific.instanceMetadataOptions.httpTokens` | **HTTP tokens** - The state of token usage for your instance metadata requests. If you set this parameter to `optional`, you can use either IMDSv1 or IMDSv2. If you set this parameter to `required`, you must use a IMDSv2 to access the instance metadata endpoint. Learn more at [What’s new in IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).|**Type:** `string`<br/>**Default:** `"required"`|
+| `global.providerSpecific.nodePoolAmi` | **Amazon machine image (AMI) for node pools** - If specified, this image will be used to provision EC2 instances for node pools.|**Type:** `string`<br/>|
 | `global.providerSpecific.region` | **Region**|**Type:** `string`<br/>|
 
 ### Apps

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -4,7 +4,12 @@ This function is used for both the `.Spec` value and as the data for the hash fu
 Any changes to this will trigger the resource to be recreated rather than attempting to update in-place.
 */}}
 {{- define "controlplane-awsmachinetemplate-spec" -}}
-{{- include "ami" $ }}
+{{- with (.Values.global.providerSpecific.controlPlaneAmi | default .Values.global.providerSpecific.ami) }}
+ami:
+  id: {{ . | quote }}
+{{- else }}
+{{- include "imageLookupParameters" $ }}
+{{- end }}
 cloudInit: {}
 instanceType: {{ .Values.global.controlPlane.instanceType }}
 nonRootVolumes:

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -61,17 +61,12 @@ giantswarm.io/prevent-deletion: "true"
 {{- end -}}
 
 {{- /*
-    "ami" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
+    "imageLookupParameters" named template renders YAML manifest that is used in AWSMachineTemplate and in AWSMachinePool resources.
 
     This template is using "cluster.os.*" named templates that are defined in the cluster chart. For more details about
     how these templates work see cluster chart docs at https://github.com/giantswarm/cluster/tree/main/helm/cluster.
 */}}
-{{- define "ami" }}
-{{- with .Values.global.providerSpecific.ami }}
-ami:
-  id: {{ . | quote }}
-{{- else -}}
-ami: {}
+{{- define "imageLookupParameters" }}
 {{- /* Get OS version. */}}
 imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
 {{- /* Get OS name, release channel and tooling version, which we use in the OS image name. */}}
@@ -81,7 +76,6 @@ imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
 {{- /* Build the OS image name. The OS images are built automatically by the CI. */}}
 imageLookupFormat: {{ $osName }}-{{$osReleaseChannel }}-{{ "{{.BaseOS}}-kube-{{.K8sVersion}}" }}-tooling-{{ $osToolingVersion }}-gs
 imageLookupOrg: "{{ if hasPrefix "cn-" (include "aws-region" .) }}306934455918{{else}}706635527432{{end}}"
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -34,7 +34,12 @@ spec:
       - {{ index $tags (keys $tags | first) | quote }}
     {{- end }}
   awsLaunchTemplate:
-    {{- include "ami" $ | nindent 4 }}
+    {{- with ($.Values.global.providerSpecific.nodePoolAmi | default $.Values.global.providerSpecific.ami) }}
+    ami:
+      id: {{ . | quote }}
+    {{- else }}
+    {{- include "imageLookupParameters" $ | nindent 4 }}
+    {{- end }}
     iamInstanceProfile: nodes-{{ $name }}-{{ include "resource.default.name" $ }}
     instanceType: {{ $value.instanceType | default "r6i.xlarge" }}
     rootVolume:

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -1692,6 +1692,11 @@
                             "minLength": 1,
                             "pattern": "^[-a-zA-Z0-9_\\.]{1,63}$"
                         },
+                        "controlPlaneAmi": {
+                            "type": "string",
+                            "title": "Amazon machine image (AMI) for control plane",
+                            "description": "If specified, this image will be used to provision EC2 instances for the control plane."
+                        },
                         "flatcarAwsAccount": {
                             "type": "string",
                             "title": "AWS account owning Flatcar image",
@@ -1714,6 +1719,11 @@
                                     "default": "required"
                                 }
                             }
+                        },
+                        "nodePoolAmi": {
+                            "type": "string",
+                            "title": "Amazon machine image (AMI) for node pools",
+                            "description": "If specified, this image will be used to provision EC2 instances for node pools."
                         },
                         "region": {
                             "type": "string",


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/32219.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
