### PR TITLE
Fix aws-nth-bundle to use the MC's kubeconfig context if it's in a different organization namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add aws-node-termination-handler bundle
 - Values: Add `global.providerSpecific.controlPlaneAmi` & `global.providerSpecific.nodePoolAmi`.
 
+### Fixed
+
+- Fix aws-nth-bundle to use the MC's kubeconfig context if it's in a different organization namespace.
+
+  Workload clusters outside the MC's `org-giantswarm` namespace failed to deploy the bundle because `HelmRelease` does not allow specifying the MC's kubeconfig secret namespace. The bundle was therefore switched to an `App`.
+
 ## [2.4.0] - 2024-11-12
 
 ### Added

--- a/helm/cluster-aws/README.md
+++ b/helm/cluster-aws/README.md
@@ -58,13 +58,13 @@ Configuration of apps that are part of the cluster.
 | `global.apps.awsEbsCsiDriverServiceMonitors.extraConfigs[*].name` | **Name** - Name of the config map or secret. The object must exist in the same namespace as the cluster App.|**Type:** `string`<br/>|
 | `global.apps.awsEbsCsiDriverServiceMonitors.extraConfigs[*].priority` | **Priority**|**Type:** `integer`<br/>**Default:** `25`|
 | `global.apps.awsEbsCsiDriverServiceMonitors.values` | **Config map** - Helm Values to be passed to the app as user config.|**Type:** `object`<br/>|
-| `global.apps.awsNodeTerminationHandler` | **App** - Configuration of a default app that is part of the cluster and is deployed as a HelmRelease resource.|**Type:** `object`<br/>|
+| `global.apps.awsNodeTerminationHandler` | **App resource** - Configuration of a default app that is part of the cluster and is deployed as an App resource.|**Type:** `object`<br/>|
 | `global.apps.awsNodeTerminationHandler.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `array`<br/>|
 | `global.apps.awsNodeTerminationHandler.extraConfigs[*]` | **Config map or secret**|**Type:** `object`<br/>|
 | `global.apps.awsNodeTerminationHandler.extraConfigs[*].kind` | **Kind** - Specifies whether the resource is a config map or a secret.|**Type:** `string`<br/>|
 | `global.apps.awsNodeTerminationHandler.extraConfigs[*].name` | **Name** - Name of the config map or secret. The object must exist in the same namespace as the cluster App.|**Type:** `string`<br/>|
-| `global.apps.awsNodeTerminationHandler.extraConfigs[*].optional` | **Optional** - Optional marks this ValuesReference as optional. When set, a not found error for the values reference is ignored, but any ValuesKey, TargetPath or transient error will still result in a reconciliation failure.|**Type:** `boolean`<br/>|
-| `global.apps.awsNodeTerminationHandler.values` | **Values** - Values to be passed to the app. Values will have higher priority than values from configmaps.|**Type:** `object`<br/>|
+| `global.apps.awsNodeTerminationHandler.extraConfigs[*].priority` | **Priority**|**Type:** `integer`<br/>**Default:** `25`|
+| `global.apps.awsNodeTerminationHandler.values` | **Config map** - Helm Values to be passed to the app as user config.|**Type:** `object`<br/>|
 | `global.apps.awsPodIdentityWebhook` | **App resource** - Configuration of a default app that is part of the cluster and is deployed as an App resource.|**Type:** `object`<br/>|
 | `global.apps.awsPodIdentityWebhook.extraConfigs` | **Extra config maps or secrets** - Extra config maps or secrets that will be used to customize to the app. The desired values must be under configmap or secret key 'values'. The values are merged in the order given, with the later values overwriting earlier, and then inline values overwriting those. Resources must be in the same namespace as the cluster.|**Type:** `array`<br/>|
 | `global.apps.awsPodIdentityWebhook.extraConfigs[*]` | **Config map or secret**|**Type:** `object`<br/>|

--- a/helm/cluster-aws/templates/aws-nth-app.yaml
+++ b/helm/cluster-aws/templates/aws-nth-app.yaml
@@ -39,47 +39,54 @@ global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
-  name: {{ include "resource.default.name" $ }}-nth-bundle
-  namespace: {{ $.Release.Namespace }}
-  annotations:
-    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
-  labels:
-    cluster-apps-operator.giantswarm.io/watching: ""
-    {{- include "labels.common" . | nindent 4 }}
-spec:
-  releaseName: aws-nth-bundle
-  chart:
-    spec:
-      chart: aws-nth-bundle
-      {{- $_ := set $ "appName" "aws-nth-bundle" }}
-      version: {{ include "cluster.app.version" $ }}
-      sourceRef:
-        kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-{{ include "cluster.app.catalog" $ }}
-  kubeConfig:
-    secretRef:
-      name: {{ $.Values.global.managementCluster }}-kubeconfig
-  interval: 5m
-  install:
-    remediation:
-      retries: 30
+---
+apiVersion: v1
+data:
   {{- $awsNodeTerminationHandlerHelmValues := (include "defaultAwsNodeTerminationHandlerHelmValues" .) | fromYaml -}}
   {{- $customAwsNodeTerminationHandlerHelmValues := $.Values.global.apps.awsNodeTerminationHandler.values -}}
   {{- if $customAwsNodeTerminationHandlerHelmValues }}
   {{- $awsNodeTerminationHandlerHelmValues = merge (deepCopy $customAwsNodeTerminationHandlerHelmValues) $awsNodeTerminationHandlerHelmValues -}}
   {{- end }}
-  {{- if $awsNodeTerminationHandlerHelmValues }}
-  values: {{- $awsNodeTerminationHandlerHelmValues | toYaml | nindent 4 }}
-  {{- end }}
-  {{- if $.Values.global.apps.awsNodeTerminationHandler.extraConfigs }}
-  valuesFrom:
-    {{- range $config := $.Values.global.apps.awsNodeTerminationHandler.extraConfigs }}
-    - kind: {{ $config.kind }}
-      name: {{ $config.name }}
-      valuesKey: values
-      optional: {{ $config.optional | default false  }}
+  values: | {{- $awsNodeTerminationHandlerHelmValues | toYaml | nindent 4 }}
+kind: ConfigMap
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ printf "%s-aws-nth-bundle-user-values" (include "resource.default.name" $) | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    {{- include "labels.common" $ | nindent 4 }}
+  name: {{ printf "%s-aws-nth-bundle" (include "resource.default.name" $) | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+spec:
+  catalog: {{ include "cluster.app.catalog" $ | quote }}
+  install:
+    timeout: "10m"
+  upgrade:
+    timeout: "10m"
+  kubeConfig:
+    inCluster: true # in management cluster context
+  name: aws-nth-bundle
+  namespace: {{ $.Release.Namespace | quote }}
+  {{- $_ := set $ "appName" "aws-nth-bundle" }}
+  {{- $appVersion := include "cluster.app.version" $ }}
+  version: {{ $appVersion }}
+  extraConfigs:
+    # See above
+    - kind: configMap
+      name: {{ printf "%s-aws-nth-bundle-user-values" (include "resource.default.name" $) | quote }}
+      namespace: {{ $.Release.Namespace | quote }}
+    {{- if .Values.global.apps.awsNodeTerminationHandler.extraConfigs }}
+    {{- range .Values.global.apps.awsNodeTerminationHandler.extraConfigs }}
+    - kind: {{ .kind }}
+      name: {{ .name }}
+      namespace: {{ .namespace | default $.Release.Namespace }}
+      priority: {{ .priority }}
     {{- end }}
-  {{- end }}
+    {{- end }}

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -709,7 +709,7 @@
                             "description": "Configuration of aws-ebs-csi-driver-servicemonitors. For all available values see https://github.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app."
                         },
                         "awsNodeTerminationHandler": {
-                            "$ref": "#/$defs/helmRelease",
+                            "$ref": "#/$defs/app",
                             "type": "object",
                             "title": "AWS Node Termination Handler",
                             "description": "Configuration of aws-nth-bundle. For all available values see https://github.com/giantswarm/aws-nth-bundle."


### PR DESCRIPTION


### What this PR does / why we need it

Forward-port of #959

Towards https://github.com/giantswarm/giantswarm/issues/31843



### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

Works for `release-v1.1.x`. We can run a full test once all forward-ports are done.

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
