### PR TITLE
Add ingress rule in nodes Security Group to allow access to the Kubelet API when using ENI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ingress rule in nodes Security Group to allow access to the Kubelet API when using ENI mode. This is needed by the metrics server to gather metrics from the Kubelet
+
 ## [2.6.0] - 2025-01-23
 
 ### Changed

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -71,6 +71,14 @@ spec:
 
         # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
         cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+    additionalNodeIngressRules:
+      - description: "Allow traffic from Pods to the Kubelet API running on the nodes"
+        protocol: "tcp"
+        fromPort: 10250
+        toPort: 10250
+
+        # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
     {{- end }}
     cni:
       cniIngressRules:


### PR DESCRIPTION
This is needed by the metrics server to gather metrics from the Kubelet

### What this PR does / why we need it



### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
