### PR TITLE
Cilium: Replace no longer supported `tunnel` option by `routingMode`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ingress rule in nodes Security Group to allow access to the Kubelet API when using ENI mode. This is needed by the metrics server to gather metrics from the Kubelet
 
+### Changed
+
+- Cilium: Replace no longer supported `tunnel` option by `routingMode`.
+
 ## [2.6.0] - 2025-01-23
 
 ### Changed

--- a/helm/cluster-aws/templates/_cilium_helmrelease_config.yaml
+++ b/helm/cluster-aws/templates/_cilium_helmrelease_config.yaml
@@ -12,7 +12,7 @@ eni:
   enabled: true
   awsReleaseExcessIPs: true
 enableIPv4Masquerade: false
-tunnel: disabled
+routingMode: native
 cluster:
     # Used by cilium to tag ENIs it creates and be able to filter and clean them up.
     name: {{ include "resource.default.name" $ | quote }}


### PR DESCRIPTION
### What this PR does / why we need it

Cilium v1.15 removed the `tunnel` option. We are still using it, but the chart did not complain about it, yet. So tunneling is still enabled as we are not setting the successor `routingMode`.

This PR replaces `tunnel` by the new option `routingMode`, so Cilium correctly acts in native routing mode instead of tunneling traffic through VXLAN while already in ENI mode.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

`/run cluster-test-suites`

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
