### PR TITLE
Scale down cilium-operator before deleting a cluster (only in eni mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Scale down cilium-operator before deleting a cluster (only in eni mode)
+
 ## [2.6.1] - 2025-02-07
 
 ### Added

--- a/helm/cluster-aws/templates/cilium-cleanup/job.yaml
+++ b/helm/cluster-aws/templates/cilium-cleanup/job.yaml
@@ -1,0 +1,72 @@
+{{- if eq (required "global.connectivity.cilium.ipamMode is required" .Values.global.connectivity.cilium.ipamMode) "eni" }}
+#
+# When working in eni mode and ENIs need to be deleted (e.g. on cluster deletion), Cilium first needs to detach
+# the ENIs from the EC2 instance, and then delete them.
+# If cilium-operator gets killed / removed after it detaches an ENI but before it deletes it, the ENI will be orphaned.
+#
+# This is a possible scenario on cluster deletion. To prevent it, this pre-delete hook will scale down cilium-operator before deleting.
+# This way ENIs remain attached to the EC2 instances and get automatically deleted by AWS upon instance termination.
+#
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "labels.common" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "resource.default.name" . }}-cilium-cleanup
+      containers:
+      - name: kubectl
+        image: {{ include "awsContainerImageRegistry" . }}/giantswarm/kubectl:{{ .Values.cluster.providerIntegration.kubernetesVersion }}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        env:
+        - name: CLUSTER
+          value: {{ include "resource.default.name" . }}
+        - name: KUBECONFIG
+          value: /etc/kubeconfig/value
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - |
+          echo "Scaling down cilium-operator on cluster ${CLUSTER} as it is about to be deleted."
+          kubectl scale --namespace kube-system deployment cilium-operator --replicas=0
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /etc/kubeconfig
+            readOnly: true
+      restartPolicy: Never
+      volumes:
+        - name: kubeconfig
+          secret:
+            secretName: {{ include "resource.default.name" . }}-kubeconfig
+            defaultMode: 420
+  ttlSecondsAfterFinished: 86400 # 24h
+{{- end }}

--- a/helm/cluster-aws/templates/cilium-cleanup/role.yaml
+++ b/helm/cluster-aws/templates/cilium-cleanup/role.yaml
@@ -1,0 +1,22 @@
+{{- if eq (required "global.connectivity.cilium.ipamMode is required" .Values.global.connectivity.cilium.ipamMode) "eni" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  resourceNames:
+  - {{ include "resource.default.name" . }}-kubeconfig
+{{- end }}

--- a/helm/cluster-aws/templates/cilium-cleanup/rolebinding.yaml
+++ b/helm/cluster-aws/templates/cilium-cleanup/rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if eq (required "global.connectivity.cilium.ipamMode is required" .Values.global.connectivity.cilium.ipamMode) "eni" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+subjects:
+- kind: ServiceAccount
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/cluster-aws/templates/cilium-cleanup/serviceaccount.yaml
+++ b/helm/cluster-aws/templates/cilium-cleanup/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if eq (required "global.connectivity.cilium.ipamMode is required" .Values.global.connectivity.cilium.ipamMode) "eni" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "resource.default.name" . }}-cilium-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

This is an attempt to prevent a race-condition on cluster deletion, where Cilium could leak ENIs, preventing the full removal of the VPC.

Towards https://github.com/giantswarm/giantswarm/issues/32350

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
