### PR TITLE
Configure HelmReleases to retry indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure HelmReleases to retry indefinitely when installation or upgrade fails by setting retries: -1.
+
 ## [3.2.1] - 2025-03-19
 
 ### Added

--- a/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-aws/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -47,7 +47,10 @@ spec:
   interval: 5m
   install:
     remediation:
-      retries: 30
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   {{- $awsEbsCsiDriverHelmValues := (include "defaultAwsEbsCsiDriverHelmValues" .) | fromYaml -}}
   {{- $customAwsEbsCsiDriverHelmValues := $.Values.global.apps.awsEbsCsiDriver.values -}}
   {{- if $customAwsEbsCsiDriverHelmValues }}

--- a/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
+++ b/helm/cluster-aws/templates/cloud-provider-aws-helmrelease.yaml
@@ -45,7 +45,10 @@ spec:
   interval: 5m
   install:
     remediation:
-      retries: 30
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   {{- $awsCloudControllerManagerHelmValues := (include "defaultAwsCloudControllerManagerHelmValues" .) | fromYaml -}}
   {{- $customAwsCloudControllerManagerHelmValues := $.Values.global.apps.awsCloudControllerManager.values -}}
   {{- if $customAwsCloudControllerManagerHelmValues }}


### PR DESCRIPTION
### What this PR does / why we need it
#
Configure HelmReleases to retry indefinitely when installation or upgrade fails by setting retries: -1.
This ensures the component will eventually deploy successfully despite temporary infrastructure issues.

I've noticed a lot of `FluxHelmReleaseFailed` alerts, where we get paged because Flux gave up too early, which required manually triggering `flux reconcile ...`.

We already added it in `cluster` chart, see https://github.com/giantswarm/cluster/pull/410.


### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->