### PR TITLE
Apply aws-ebs-csi-driver taints on all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `cert-manager-crossplane-resources` App in private clusters so `DNS01` `clusterIssuer`.
 - Add configuration for `DNS01` `clusterIssuer` deployed by `cert-manager-app` in private clusters.
+- Apply taint for AWS EBS CSI driver on all nodes.
 
 ### Changed
 

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -55,6 +55,37 @@
             "minLength": 0,
             "pattern": "^[ a-zA-Z0-9\\._:/=+-@]+$"
         },
+        "customNodeTaints": {
+            "type": "array",
+            "title": "Custom node taints",
+            "items": {
+                "type": "object",
+                "required": [
+                    "effect",
+                    "key"
+                ],
+                "properties": {
+                    "effect": {
+                        "type": "string",
+                        "title": "Effect",
+                        "enum": [
+                            "NoSchedule",
+                            "PreferNoSchedule",
+                            "NoExecute"
+                        ]
+                    },
+                    "key": {
+                        "type": "string",
+                        "title": "Key"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    }
+                }
+            },
+            "default": []
+        },
         "helmRelease": {
             "type": "object",
             "title": "App",
@@ -566,7 +597,13 @@
                                     }
                                 }
                             }
-                        }
+                        },
+                        "taints": [
+                            {
+                                "effect": "NoExecute",
+                                "key": "ebs.csi.aws.com/agent-not-ready"
+                            }
+                        ]
                     },
                     "osImage": {
                         "variant": "3"

--- a/helm/cluster-aws/values.yaml
+++ b/helm/cluster-aws/values.yaml
@@ -185,6 +185,9 @@ cluster:
               units:
                 - enabled: true
                   name: kubelet-aws-config.service
+      taints:
+        - effect: NoExecute
+          key: ebs.csi.aws.com/agent-not-ready
     osImage:
       variant: "3"
     pauseProperties:


### PR DESCRIPTION
### What this PR does / why we need it

Applies a startup taint on all nodes that will be removed by the AWS EBS CSI driver once the agent is ready.
Resolves https://github.com/giantswarm/giantswarm/issues/31687.

I still need to test if it's okay to apply this on control planes, and what this means in general for our deployment process.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
