### PR TITLE
Only deploy NTH when using non karpenter node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only deploy `node-termination-handler` when there are non karpenter node pools.
+
 ## [3.4.0] - 2025-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Only deploy `node-termination-handler` when there are non karpenter node pools.
+- Only deploy `node-termination-handler` when there are non-karpenter node pools because karpenter takes care of node draining
 
 ## [3.4.0] - 2025-06-12
 

--- a/helm/cluster-aws/ci/test-karpenter-mixed-with-regular-nodepools-values.yaml
+++ b/helm/cluster-aws/ci/test-karpenter-mixed-with-regular-nodepools-values.yaml
@@ -6,6 +6,12 @@ global:
   connectivity:
     baseDomain: example.com
   nodePools:
+    pool0:
+      maxSize: 2
+      minSize: 2
+      instanceTypeOverrides:
+        - r6i.xlarge
+        - m5.xlarge
     pool1:
       type: karpenter
       requirements:

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -147,3 +147,12 @@ giantswarm.io/cluster: {{ include "resource.default.name" $ }}
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "hasAWSMachinePools" -}}
+{{- range $name, $value := .Values.global.nodePools }}
+  {{- if ne $value.type "karpenter" }}
+    {{- print "true" -}}
+    {{- break -}}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/cluster-aws/templates/aws-nth-app.yaml
+++ b/helm/cluster-aws/templates/aws-nth-app.yaml
@@ -41,7 +41,7 @@ global:
   podSecurityStandards:
     enforced: {{ .Values.global.podSecurityStandards.enforced }}
 {{- end }}
-{{- if .Values.global.providerSpecific.nodeTerminationHandlerEnabled }}
+{{- if and (include "hasAWSMachinePools" .) .Values.global.providerSpecific.nodeTerminationHandlerEnabled }}
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
### What this PR does / why we need it

karpenter already takes care of draining the nodes that are being terminated. There is no need to use the node termination handler when using only karpenter node pools. It's still required when using non karpenter node pools though.

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
