### PR TITLE
Use reduced IAM permissions on karpenter worker nodes instance profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use reduced IAM permissions on `karpenter` worker nodes instance profile. This can be toggled back with `global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers`.
+
 ## [3.4.0] - 2025-06-12
 
 ### Changed

--- a/helm/cluster-aws/templates/_karpenter_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_karpenter_machine_pools.tpl
@@ -7,6 +7,9 @@ metadata:
   labels:
     giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
     {{- include "labels.common" $ | nindent 4 }}
+    {{- if (required "global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers is required" $.Values.global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers) }}
+    alpha.aws.giantswarm.io/reduced-instance-permissions-workers: "true"
+    {{- end }}
     app.kubernetes.io/version: {{ $.Chart.Version | quote }}
   name: {{ include "resource.default.name" $ }}-{{ $name }}
   namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION
### What this PR does / why we need it

We already use reduced IAM permissions on regular `AWSMachinePools`, but we also want to do the same on `karpenter` node pools.

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
