### PR TITLE
Use static string for imageLookupFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Only deploy `node-termination-handler` when there are non-karpenter node pools because karpenter takes care of node draining
+- Change `imageLookupFormat` to use a static string rather than CAPI replacing the OS and Kubernetes versions.
 
 ### Fixed
 

--- a/helm/cluster-aws/templates/_helpers.tpl
+++ b/helm/cluster-aws/templates/_helpers.tpl
@@ -72,9 +72,12 @@ imageLookupBaseOS: "{{ include "cluster.os.version" $ }}"
 {{- /* Get OS name, release channel and tooling version, which we use in the OS image name. */}}
 {{- $osName := include "cluster.os.name" $ }}
 {{- $osReleaseChannel := include "cluster.os.releaseChannel" $ }}
+{{- $osVersion := include "cluster.os.version" $ }}
 {{- $osToolingVersion := include "cluster.os.tooling.version" $ }}
+{{- $k8sVersion := include "cluster.component.kubernetes.version" $ }}
 {{- /* Build the OS image name. The OS images are built automatically by the CI. */}}
-imageLookupFormat: {{ $osName }}-{{$osReleaseChannel }}-{{ "{{.BaseOS}}-kube-{{.K8sVersion}}" }}-tooling-{{ $osToolingVersion }}-gs
+{{- /* Example result: `flatcar-stable-4230.2.0-kube-1.33.2-tooling-1.26.1-gs` */}}
+imageLookupFormat: {{ $osName }}-{{$osReleaseChannel }}-{{$osVersion}}-kube-{{$k8sVersion}}-tooling-{{ $osToolingVersion }}-gs
 imageLookupOrg: "{{ if hasPrefix "cn-" (include "aws-region" .) }}306934455918{{else}}706635527432{{end}}"
 {{- end }}
 


### PR DESCRIPTION
### What this PR does / why we need it

Replaces the CAPI-based template strings in `imageLookupFormat` with a static string generated by Helm. This should hopefully prevent errors during upgrades while the MachinePool is paused waiting for the control plane to complete.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
