### PR TITLE
Backport IMDS hop limit to v2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ingress rule in nodes Security Group to allow access to the Cilium Relay when using ENI mode.
+
 ## [2.6.1] - 2025-02-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.4] - 2024-08-04
+
+### Changed
+
+- Reduce IMDS Response Hop Limit to 2 if pod networking is in ENI mode to increase security.
+
 ## [2.6.3] - 2025-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.3] - 2025-03-19
+
 ### Added
 
 - Add ingress rule in nodes Security Group to allow access for monitoring Chart Operator, EBS CSI Controller, Cilium Operator and Node Exporter.
@@ -1574,7 +1576,8 @@ yq eval --inplace '
 
 ## [0.1.0] - 2022-02-25
 
-[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v2.6.2...HEAD
+[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v2.6.3...HEAD
+[2.6.3]: https://github.com/giantswarm/cluster-aws/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/giantswarm/cluster-aws/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/giantswarm/cluster-aws/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/giantswarm/cluster-aws/compare/v2.5.0...v2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.2] - 2025-03-07
+
 ### Added
 
 - Add ingress rule in nodes Security Group to allow access to the Cilium Relay when using ENI mode.
@@ -1568,7 +1570,8 @@ yq eval --inplace '
 
 ## [0.1.0] - 2022-02-25
 
-[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v2.6.1...HEAD
+[Unreleased]: https://github.com/giantswarm/cluster-aws/compare/v2.6.2...HEAD
+[2.6.2]: https://github.com/giantswarm/cluster-aws/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/giantswarm/cluster-aws/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/giantswarm/cluster-aws/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/giantswarm/cluster-aws/compare/v2.4.0...v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ingress rule in nodes Security Group to allow access for monitoring Chart Operator, EBS CSI Controller, Cilium Operator and Node Exporter.
+
 ## [2.6.2] - 2025-03-07
 
 ### Added

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-aws
 type: application
-version: 2.6.1
+version: 2.6.2
 description: A helm chart for creating Cluster API clusters with the AWS infrastructure provider (CAPA).
 icon: https://s.giantswarm.io/app-icons/aws/2/dark.svg
 home: https://github.com/giantswarm/cluster-aws

--- a/helm/cluster-aws/Chart.yaml
+++ b/helm/cluster-aws/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-aws
 type: application
-version: 2.6.2
+version: 2.6.3
 description: A helm chart for creating Cluster API clusters with the AWS infrastructure provider (CAPA).
 icon: https://s.giantswarm.io/app-icons/aws/2/dark.svg
 home: https://github.com/giantswarm/cluster-aws

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -72,18 +72,40 @@ spec:
         # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
         cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
     additionalNodeIngressRules:
-      - description: "Allow traffic from Pods to the Kubelet API running on the nodes"
-        protocol: "tcp"
-        fromPort: 10250
-        toPort: 10250
-
-        # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
-        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
       - description: "Allow traffic from Pods to the Cilium Relay port running on the nodes"
         protocol: "tcp"
         fromPort: 4244
         toPort: 4244
-        # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to Chart Operator running on the nodes"
+        protocol: "tcp"
+        fromPort: 8000
+        toPort: 8000
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to EBS CSI Controller running on the nodes"
+        protocol: "tcp"
+        fromPort: 8610
+        toPort: 8610
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to Cilium Operator and Envoy running on the nodes"
+        protocol: "tcp"
+        fromPort: 9963
+        toPort: 9964
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to the Kubelet API running on the nodes"
+        protocol: "tcp"
+        fromPort: 10250
+        toPort: 10250
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to Node Exporter running on the nodes"
+        protocol: "tcp"
+        fromPort: 10300
+        toPort: 10300
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to Kubernetes Resource Count Exporter running on the nodes"
+        protocol: "tcp"
+        fromPort: 10999
+        toPort: 10999
         cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
     {{- end }}
     cni:

--- a/helm/cluster-aws/templates/_aws_cluster.tpl
+++ b/helm/cluster-aws/templates/_aws_cluster.tpl
@@ -79,6 +79,12 @@ spec:
 
         # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
         cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
+      - description: "Allow traffic from Pods to the Cilium Relay port running on the nodes"
+        protocol: "tcp"
+        fromPort: 4244
+        toPort: 4244
+        # We could also use `sourceSecurityGroupIds` here, but the ID of the "<cluster>-pods" security group isn't known yet
+        cidrBlocks: {{ required "global.connectivity.network.pods.cidrBlocks is required" .Values.global.connectivity.network.pods.cidrBlocks | toYaml | nindent 10 }}
     {{- end }}
     cni:
       cniIngressRules:

--- a/helm/cluster-aws/templates/_control_plane.tpl
+++ b/helm/cluster-aws/templates/_control_plane.tpl
@@ -37,7 +37,11 @@ additionalSecurityGroups:
 {{- toYaml .Values.global.controlPlane.additionalSecurityGroups | nindent 2 }}
 {{- end }}
 instanceMetadataOptions:
+{{- if eq (required "global.connectivity.cilium.ipamMode is required" .Values.global.connectivity.cilium.ipamMode) "eni" }}
+  httpPutResponseHopLimit: 2
+{{- else }}
   httpPutResponseHopLimit: 3
+{{- end }}
   httpTokens: {{ .Values.global.providerSpecific.instanceMetadataOptions.httpTokens | quote }}
 sshKeyName: ""
 subnet:

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -73,7 +73,11 @@ spec:
       maxPrice: {{ $value.spotInstances.maxPrice | quote }}
     {{- end }}
     instanceMetadataOptions:
+      {{- if eq (required "global.connectivity.cilium.ipamMode is required" $.Values.global.connectivity.cilium.ipamMode) "eni" }}
+      httpPutResponseHopLimit: 2
+      {{- else }}
       httpPutResponseHopLimit: 3
+      {{- end }}
       httpTokens: {{ $.Values.global.providerSpecific.instanceMetadataOptions.httpTokens | quote }}
   minSize: {{ $value.minSize | default 1 }}
   maxSize: {{ $value.maxSize | default 3 }}


### PR DESCRIPTION
### What this PR does / why we need it

Backports 3ad7e4935fafc5ff18d14c7ba72a21c616069615 to new patch release v2.6.4. Relates to https://github.com/giantswarm/giantswarm/issues/33985.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
