### PR TITLE
Add cluster chart nodepool fields to the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `cluster` chart nodepool fields to the schema.
+
 ## [4.0.1] - 2025-09-02
 
 ### Changed

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -537,6 +537,19 @@
                                         }
                                     }
                                 },
+                                "annotations": {
+                                    "type": "object",
+                                    "title": "Annotations",
+                                    "description": "These annotations are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^([a-zA-Z0-9/\\.-]{1,253}/)?[a-zA-Z0-9/\\._-]{1,63}$": {
+                                            "type": "string",
+                                            "title": "Annotation",
+                                            "minLength": 1
+                                        }
+                                    }
+                                },
                                 "availabilityZones": {
                                     "type": "array",
                                     "title": "Availability zones",
@@ -558,6 +571,12 @@
                                             "minimum": 30
                                         }
                                     }
+                                },
+                                "cgroupsv1": {
+                                    "type": "boolean",
+                                    "title": "Cgroups v1",
+                                    "description": "Flag that indicates if cgroups v1 should be used.",
+                                    "default": false
                                 },
                                 "customNodeLabels": {
                                     "type": "array",
@@ -614,6 +633,21 @@
                                 "instanceWarmup": {
                                     "type": "integer",
                                     "title": "Time interval, in seconds, between node replacement."
+                                },
+                                "labels": {
+                                    "type": "object",
+                                    "title": "Labels",
+                                    "description": "These labels are added to all Kubernetes resources defining this node pool.",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^[a-zA-Z0-9/\\._-]+$": {
+                                            "type": "string",
+                                            "title": "Label",
+                                            "maxLength": 63,
+                                            "minLength": 0,
+                                            "pattern": "^[a-zA-Z0-9/\\._-]*$"
+                                        }
+                                    }
                                 },
                                 "libVolumeSizeGB": {
                                     "type": "integer",


### PR DESCRIPTION
### What this PR does / why we need it

When defining values for fields defined in the `cluster` chart schema but not in the `cluster-aws` schema, the schema validation for `cluster-aws` fails because those fields are not defined.

### Checklist

- [X] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
