### PR TITLE
Reduce heartbeat timeout for ASG lifecycle hooks to from 30 minutes to 3 minutes since aws-node-termination-handler-app (NTH) can now send heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The container registry passed as value to default apps is set to `gsoci.azurecr.io`, regardless of the cluster region. The mirroring feature of `containerd` will make sure the right registry is used.
 - Switch to HelmReleases to install `karpenter` and `karpenter-crossplane-resources` charts.
 - Bump flux `HelmReleases` api version to v2.
+- Reduce heartbeat timeout for ASG lifecycle hooks to from 30 minutes to 3 minutes since aws-node-termination-handler-app (NTH) can now send heartbeats
 
 ### Removed
 

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -112,12 +112,11 @@ spec:
   - defaultResult: CONTINUE
 
     {{/*
-        The default is a high enough heartbeat timeout because aws-node-termination-handler (shortened to "NTH" here)
-        doesn't send heartbeats (https://github.com/aws/aws-node-termination-handler/issues/493),
-        but low enough so that if the controller is down, instances can still terminate within
-        a reasonable time.
+        Since aws-node-termination-handler-app (shortened to "NTH" here) was improved to send
+        heartbeats, this can be a low value. If NTH is down or cannot send heartbeats, this allows
+        instances to be terminated in a reasonable time - for example during cluster deletion.
     */}}
-    heartbeatTimeout: "{{ ($value.awsNodeTerminationHandler).heartbeatTimeoutSeconds | default 1800 }}s"
+    heartbeatTimeout: "{{ ($value.awsNodeTerminationHandler).heartbeatTimeoutSeconds | default 180 }}s"
 
     lifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
     name: aws-node-termination-handler

--- a/helm/cluster-aws/values.schema.json
+++ b/helm/cluster-aws/values.schema.json
@@ -576,7 +576,6 @@
                                         "heartbeatTimeoutSeconds": {
                                             "type": "number",
                                             "title": "Heartbeat timeout for ASG lifecycle hook",
-                                            "default": 1800,
                                             "maximum": 7200,
                                             "minimum": 30
                                         }


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/32232

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites TARGET_SUITES=./providers/capa/standard

<!-- If you want to disable Helm template rendering diffs as GitHub comment, uncomment this (command must be on its own line): -->

<!-- /no_diffs_printing -->
