### PR TITLE
fix: [v7.7 backport] add note-termination-handler tag on AWS machine pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `note-termination-handler/managed: "true"` tag on `AWSMachinePools`.
+
 ## [7.7.2] - 2026-05-20
 
 ### Changed

--- a/helm/cluster-aws/templates/_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_machine_pools.tpl
@@ -17,6 +17,9 @@ spec:
   additionalTags:
     k8s.io/cluster-autoscaler/enabled: "true"
     giantswarm.io/machinepool: {{ $name }}
+    {{- if $.Values.global.providerSpecific.nodeTerminationHandlerEnabled }}
+    aws-node-termination-handler/managed: "true"
+    {{- end}}
     {{- if $.Values.global.providerSpecific.additionalNodeTags }}
     {{- toYaml $.Values.global.providerSpecific.additionalNodeTags | nindent 4 }}
     {{- end}}


### PR DESCRIPTION
### What this PR does / why we need it

Without this, NTH just ignores any interruption event from those nodes

This was working before `aws-nth-bundle` v2.0.0 because we were using our own helm chart and it was forcing nth to ignore the tag.

But ideally NTH shouldn't ignore the tag, and it should only act on the instances that it manages, specially now that we have karpenter and it handles the interruption of its own instances.

### Checklist

- [x] Updated CHANGELOG.md.