### PR TITLE
chore: migrate cert-manager values for v4.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `cert-manager` to v4.0.0 and migrated the values to match the new chart's schema.
+
 ## [8.7.0] - 2026-06-18
 
 ### Changed

--- a/helm/cluster-aws/templates/cert_manager_config.yaml
+++ b/helm/cluster-aws/templates/cert_manager_config.yaml
@@ -3,16 +3,17 @@
 {{- define "awsCertManagerHelmValues" }}
 {{- $_ := set $ "appName" "cert-manager-crossplane-resources" }}
 {{- if and (include "useCertManagerDnsChallenges" $ | eq "true") (include "cluster.app.in-release" $ | eq "true") }}
-dns01RecursiveNameserversOnly: true
-ingressShim:
-  defaultIssuerName: letsencrypt-giantswarm
-  defaultIssuerKind: ClusterIssuer
-  defaultIssuerGroup: cert-manager.io
+cert-manager:
+  dns01RecursiveNameserversOnly: true
+  ingressShim:
+    defaultIssuerName: letsencrypt-giantswarm
+    defaultIssuerKind: ClusterIssuer
+    defaultIssuerGroup: cert-manager.io
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:{{ include "aws-partition" $ }}:iam::{{ include "aws-account-id" $ }}:role/{{ include "resource.default.name" $ }}-cert-manager
 ciliumNetworkPolicy:
   enabled: true
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:{{ include "aws-partition" $ }}:iam::{{ include "aws-account-id" $ }}:role/{{ include "resource.default.name" $ }}-cert-manager
 giantSwarmClusterIssuer:
   acme:
     dns01:


### PR DESCRIPTION
> [!WARNING]
> This PR depends on the v4.0.1 cert-manager release:
> https://github.com/giantswarm/cert-manager-app/releases/tag/v4.0.1

`cert-manager` now vendors upstream `cert-manager` as a subchart, so its upstream values live under a `cert-manager`: key. The values we pass to `cert-manager-app` from the cluster charts need to move accordingly.

Towards: https://github.com/giantswarm/giantswarm/issues/36890

