### PR TITLE
ci: bump architect orb to 9.5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.14.1
+  architect: giantswarm/architect@9.5.5
 
 workflows:
   build:


### PR DESCRIPTION
## What

Bumps the `architect` CircleCI orb from `6.14.1` to `9.5.5` on `release-v7.7.x`.

## Why

The `6.14.1` orb pushes charts to the `gsoci.azurecr.io` OCI registry through a step named `[deprecated] architect/push-helm-package: Authenticate to the OCI registry`. That auth mechanism has since been decommissioned, so OCI publishing from this branch no longer works:

- `cluster-aws` `7.7.3` was published to the GH-Pages `cluster-catalog` ✅ but is **missing from gsoci OCI** ❌ (`7.7.2`, released in May while the old auth still worked, is present).
- This blocks the platform release [releases#2383 (v34.4.1)](https://github.com/giantswarm/releases/pull/2383), whose `prepare-capa` job retags the chart from gsoci OCI.

`main` and the 8.x release branches already use architect 8.x/9.x. The diff to main's config is *only* the orb version — the `push-to-app-catalog` job params are unchanged — so this is a drop-in bump.

## Follow-up

After merge, re-tag `v7.7.3` at the new commit to re-run the (now-working) OCI publish.