### PR TITLE
fix: correct taint key for ARM instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct taint key for ARM instances.
+
 ## [8.9.0] - 2026-07-17
 
 ### Changed

--- a/helm/cluster-aws/templates/_karpenter_machine_pools.tpl
+++ b/helm/cluster-aws/templates/_karpenter_machine_pools.tpl
@@ -161,7 +161,7 @@ spec:
         taints:
         {{- if eq $value.architecture "arm64" }}
         - effect: NoSchedule
-          key: node.kubernetes.io/arch
+          key: kubernetes.io/arch
           value: arm64
         {{- end }}
         {{- with $value.customNodeTaints }}


### PR DESCRIPTION
### What this PR does / why we need it

Aligns the taint with the recommended format: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-arch

### Checklist

- [x] Updated CHANGELOG.md
