### PR TITLE
chore: stop passing image.registry to the cilium app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CI: Run the full set of E2E test suites automatically on release PRs, via `.github/release-pr-body.md`. Towards https://github.com/giantswarm/roadmap/issues/4334
 
+### Removed
+
+- Stop passing `image.registry` to the cilium app ([roadmap#3264](https://github.com/giantswarm/roadmap/issues/3264)). `cilium-app` no longer has that value — the registry is part of each image's `repository` there now. The line was already a no-op: `awsContainerImageRegistry` has returned a constant `gsoci.azurecr.io` since #1433 removed its `cn-` branch, which is exactly what the cilium chart already defaults to. Rendered manifests lose only those two lines. `awsContainerImageRegistry` itself stays — coredns, cloud-provider-aws, aws-ebs-csi-driver, karpenter and cilium-cleanup still use it.
+
 ## [9.0.0] - 2026-08-04
 
 ### Changed

--- a/helm/cluster-aws/templates/_cilium_helmrelease_config.yaml
+++ b/helm/cluster-aws/templates/_cilium_helmrelease_config.yaml
@@ -2,8 +2,6 @@
 {{/* https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.yaml*/}}
 {{- define "awsCiliumHelmValues" }}
 provider: capa
-image:
-  registry: {{ include "awsContainerImageRegistry" $ }}
 {{- if eq .Values.global.connectivity.cilium.ipamMode "eni" }}
 # https://docs.cilium.io/en/v1.14/network/concepts/routing/#id5
 ipam:


### PR DESCRIPTION
### What this PR does / why we need it

Stops passing `image.registry` to the cilium app. Pairs with [cilium-app#496](https://github.com/giantswarm/cilium-app/pull/496), which removes that value from the chart ([roadmap#3264](https://github.com/giantswarm/roadmap/issues/3264)).

This line was already a no-op before either PR: `awsContainerImageRegistry` has returned a constant `gsoci.azurecr.io` since #1433 removed its `cn-` branch, which is exactly what the cilium chart already defaults to. Registry redirection for China and air-gapped installs happens at the containerd layer now (`global.components.containerd.containerRegistries`), not through per-chart values.

Strictly speaking this is cleanup rather than a requirement — cilium's `values.schema.json` has no `additionalProperties: false`, so an unknown `image.registry` key would simply be ignored. It is worth removing anyway because it is the last reference to cilium's `image.registry` anywhere in the org, and leaving it would suggest cilium still honours a registry knob that no longer exists.

`awsContainerImageRegistry` itself stays — `coredns`, `cloud-provider-aws`, `aws-ebs-csi-driver`, `karpenter` and `cilium-cleanup` still use it.

**Ordering:** these two PRs are independent. A cluster still on the current cilium-app renders identical images either way.

**Verified:** full `helm template` of the chart with `ci/test-eni-mode-values.yaml`, before vs after — the diff is exactly the two removed lines, nothing else.

### Checklist

- [x] Updated CHANGELOG.md.

### Trigger E2E tests

/run cluster-test-suites
